### PR TITLE
Introduce ValidationError with main functionality

### DIFF
--- a/.changeset/lovely-walls-suffer.md
+++ b/.changeset/lovely-walls-suffer.md
@@ -1,0 +1,5 @@
+---
+'@causaly/zod-validation-error': minor
+---
+
+Initial functionality

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright 2021 Causaly
+(The MIT License)
+
+Copyright 2022 Causaly, Inc <front-end@causaly.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,62 @@
-# Typescript-pkg-template
+# zod-validation-error
 
-Simple Typescript template to quickstart your next project
+Wrap zod validation errors in user-friendly readable messages.
 
-## Instructions
+[![Build Status](https://github.com/causaly/zod-validation-error/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/causaly/zod-validation-error/actions/workflows/ci.yml) [![npm version](https://badge.fury.io/js/zod-validation-error.svg)](https://www.npmjs.com/package/zod-validation-error)
 
-- Click the `Use this template` button
-- Configure SWC. You can find the configuration files under `/config`
-- Update the appropriate metadata in `package.json`, depending on the environments you'll use
-- Write your code under `/lib`
+#### Features
 
-## Notes
+- User-friendly readable messages;
+- Maintain original errors under `error.details`;
+- Extensive tests.
 
-The package by default exports artifacts for both browser & node environments
+## Installation
 
-## Publishing
+```bash
+npm install zod-validation-error
+```
 
-The repo is using changesets and the accompanying GitHub action to handle versioning, keeping a changelong and publishing to NPM. 
-You can read more about the changesets package [here](https://github.com/changesets/changesets).
+#### Requirements
+
+- Node.js v.14+
+
+## Quick start
+
+```typescript
+// create zod schema
+const zodSchema = zod.object({
+  id: zod.number().int().positive(),
+  email: zod.string().email(),
+});
+
+// parse some invalid value
+try {
+  zodSchema.parse({
+    id: 1,
+    email: 'foobar', // note: invalid email
+  });
+} catch (err) {
+  const validationError = fromZodError(err);
+  // the error now is readable by the user
+  // you may print it to console
+  // or return it via an API
+  console.log(validationError);
+}
+```
+
+## Motivation
+
+Zod errors are difficult to consume for the end-user.
+
+This library wraps zod validation errors in user-friendly readable messages that can be exposed to the outer world, while maintaining the original errors in an array for dev use.
+
+## Contribute
+
+Source code contributions are most welcome. Please open a PR, ensure the linter is satisfied and all tests pass.
+
+#### We are hiring
+
+Causaly is building the world's largest biomedical knowledge platform, using technologies such as TypeScript, React and Node.js. Find out more about our openings at https://apply.workable.com/causaly/.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Wrap zod validation errors in user-friendly readable messages.
 
 #### Features
 
-- User-friendly readable messages;
+- User-friendly readable messages, configurable via options;
 - Maintain original errors under `error.details`;
 - Extensive tests.
 
@@ -46,9 +46,36 @@ try {
 
 ## Motivation
 
-Zod errors are difficult to consume for the end-user.
+Zod errors are difficult to consume for the end-user. This library wraps Zod validation errors in user-friendly readable messages that can be exposed to the outer world, while maintaining the original errors in an array for _dev_ use.
 
-This library wraps zod validation errors in user-friendly readable messages that can be exposed to the outer world, while maintaining the original errors in an array for dev use.
+### Example
+
+#### Input (from Zod)
+
+```json
+[
+  {
+    "code": "too_small",
+    "inclusive": false,
+    "message": "Number must be greater than 0",
+    "minimum": 0,
+    "path": ["id"],
+    "type": "number"
+  },
+  {
+    "code": "invalid_string",
+    "message": "Invalid email",
+    "path": ["email"],
+    "validation": "email"
+  }
+]
+```
+
+#### Output
+
+```
+Validation error: Number must be greater than 0 at "id"; Invalid email at "email"
+```
 
 ## Contribute
 

--- a/config/jest.config.ts
+++ b/config/jest.config.ts
@@ -1,8 +1,16 @@
 import type { Config } from '@jest/types';
 
 const config: Config.InitialOptions = {
-  verbose: true,
+  rootDir: '..',
+  testEnvironment: 'node',
+  collectCoverageFrom: ['lib/**/*.{js,ts}'],
   testRegex: './lib/.*\\.(test|spec)\\.(js|ts)$',
+  verbose: true,
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.json',
+    },
+  },
   transform: {
     '^.+\\.ts?$': 'ts-jest',
   },

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -1,0 +1,205 @@
+import * as zod from 'zod';
+
+import {
+  fromZodError,
+  isValidationError,
+  ValidationError,
+} from './ValidationError';
+
+describe('fromZodError()', () => {
+  test('handles zod.string() schema errors', () => {
+    const emailSchema = zod.string().email();
+
+    try {
+      emailSchema.parse('foobar');
+    } catch (err) {
+      const validationError = fromZodError(err);
+      expect(validationError).toBeInstanceOf(ValidationError);
+      expect(validationError.message).toMatchInlineSnapshot(
+        `"Validation error: Invalid email"`
+      );
+      expect(validationError.details).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "code": "invalid_string",
+            "message": "Invalid email",
+            "path": Array [],
+            "validation": "email",
+          },
+        ]
+      `);
+    }
+  });
+
+  test('handles zod.object() schema errors', () => {
+    const objSchema = zod.object({
+      id: zod.number().int().positive(),
+      name: zod.string().min(2),
+    });
+
+    try {
+      objSchema.parse({
+        id: -1,
+        name: 'a',
+      });
+    } catch (err) {
+      const validationError = fromZodError(err);
+      expect(validationError).toBeInstanceOf(ValidationError);
+      expect(validationError.message).toMatchInlineSnapshot(
+        `"Validation error: Number must be greater than 0 at \\"id\\"; String must contain at least 2 character(s) at \\"name\\""`
+      );
+      expect(validationError.details).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "code": "too_small",
+            "inclusive": false,
+            "message": "Number must be greater than 0",
+            "minimum": 0,
+            "path": Array [
+              "id",
+            ],
+            "type": "number",
+          },
+          Object {
+            "code": "too_small",
+            "inclusive": true,
+            "message": "String must contain at least 2 character(s)",
+            "minimum": 2,
+            "path": Array [
+              "name",
+            ],
+            "type": "string",
+          },
+        ]
+      `);
+    }
+  });
+
+  test('handles zod.array() schema errors', () => {
+    const objSchema = zod.array(zod.number().int());
+
+    try {
+      objSchema.parse([1, 'a', true, 1.23]);
+    } catch (err) {
+      const validationError = fromZodError(err);
+      expect(validationError).toBeInstanceOf(ValidationError);
+      expect(validationError.message).toMatchInlineSnapshot(
+        `"Validation error: Expected number, received string at \\"[1]\\"; Expected number, received boolean at \\"[2]\\"; Expected integer, received float at \\"[3]\\""`
+      );
+      expect(validationError.details).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "code": "invalid_type",
+            "expected": "number",
+            "message": "Expected number, received string",
+            "path": Array [
+              1,
+            ],
+            "received": "string",
+          },
+          Object {
+            "code": "invalid_type",
+            "expected": "number",
+            "message": "Expected number, received boolean",
+            "path": Array [
+              2,
+            ],
+            "received": "boolean",
+          },
+          Object {
+            "code": "invalid_type",
+            "expected": "integer",
+            "message": "Expected integer, received float",
+            "path": Array [
+              3,
+            ],
+            "received": "float",
+          },
+        ]
+      `);
+    }
+  });
+
+  test('handles nested zod.object() schema errors', () => {
+    const objSchema = zod.object({
+      id: zod.number().int().positive(),
+      arr: zod.array(zod.number().int()),
+      nestedObj: zod.object({
+        name: zod.string().min(2),
+      }),
+    });
+
+    try {
+      objSchema.parse({
+        id: -1,
+        arr: [1, 'a'],
+        nestedObj: {
+          name: 'a',
+        },
+      });
+    } catch (err) {
+      const validationError = fromZodError(err);
+      expect(validationError).toBeInstanceOf(ValidationError);
+      expect(validationError.message).toMatchInlineSnapshot(
+        `"Validation error: Number must be greater than 0 at \\"id\\"; Expected number, received string at \\"arr[1]\\"; String must contain at least 2 character(s) at \\"nestedObj.name\\""`
+      );
+      expect(validationError.details).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "code": "too_small",
+            "inclusive": false,
+            "message": "Number must be greater than 0",
+            "minimum": 0,
+            "path": Array [
+              "id",
+            ],
+            "type": "number",
+          },
+          Object {
+            "code": "invalid_type",
+            "expected": "number",
+            "message": "Expected number, received string",
+            "path": Array [
+              "arr",
+              1,
+            ],
+            "received": "string",
+          },
+          Object {
+            "code": "too_small",
+            "inclusive": true,
+            "message": "String must contain at least 2 character(s)",
+            "minimum": 2,
+            "path": Array [
+              "nestedObj",
+              "name",
+            ],
+            "type": "string",
+          },
+        ]
+      `);
+    }
+  });
+});
+
+describe('isValidationError()', () => {
+  test('returns true when argument is instance of ValidationError', () => {
+    expect(
+      isValidationError(new ValidationError('foobar', { details: [] }))
+    ).toEqual(true);
+  });
+
+  test('returns false when argument is plain Error', () => {
+    expect(isValidationError(new Error('foobar'))).toEqual(false);
+  });
+
+  test('returns false when argument is not an Error', () => {
+    expect(isValidationError('foobar')).toEqual(false);
+    expect(isValidationError(123)).toEqual(false);
+    expect(
+      isValidationError({
+        message: 'foobar',
+      })
+    ).toEqual(false);
+  });
+});

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -1,0 +1,65 @@
+import * as zod from 'zod';
+
+import { joinPath } from './utils/joinPath';
+
+const PREFIX_COPY = 'Validation error';
+const MAX_ISSUES_IN_REASON = 10;
+
+export class ValidationError extends Error {
+  details: Array<Zod.ZodIssue>;
+
+  constructor(
+    message: string,
+    options: {
+      details: Array<Zod.ZodIssue>;
+    }
+  ) {
+    super(message);
+    this.details = options.details;
+  }
+}
+
+/**
+ * Converts the supplied ZodError to ValidationError.
+ * @param zodError {zod.ZodError}
+ * @return {ValidationError}
+ */
+export function fromZodError(zodError: zod.ZodError): ValidationError {
+  const reason = zodError.errors
+    // limit max number of issues printed in the reason section
+    .slice(0, MAX_ISSUES_IN_REASON)
+    // format error message
+    .map((issue) => {
+      const { message, path } = issue;
+
+      if (path.length > 0) {
+        return message + ' at "' + joinPath(path) + '"';
+      }
+
+      return message;
+    })
+    // concat as string
+    .join('; ');
+
+  const message = reason ? [PREFIX_COPY, reason].join(': ') : PREFIX_COPY;
+
+  return new ValidationError(message, {
+    details: zodError.errors,
+  });
+}
+
+export function toValidationError(err: unknown): ValidationError | Error {
+  if (err instanceof zod.ZodError) {
+    return fromZodError(err);
+  }
+
+  if (err instanceof Error) {
+    return err;
+  }
+
+  return new Error('Unknown error');
+}
+
+export function isValidationError(err: unknown): err is ValidationError {
+  return err instanceof ValidationError;
+}

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -40,7 +40,7 @@ export function fromZodError(
       const { message, path } = issue;
 
       if (path.length > 0) {
-        return message + ' at "' + joinPath(path) + '"';
+        return `${message} at "${joinPath(path)}"`;
       }
 
       return message;

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -26,7 +26,7 @@ export function fromZodError(
   } = {}
 ): ValidationError {
   const {
-    maxIssuesInMessage = 10,
+    maxIssuesInMessage = 99, // I've got 99 problems but the b$tch ain't one
     issueSeparator = '; ',
     prefixSeparator = ': ',
     prefix = 'Validation error',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,6 @@
-export { sum } from './sum';
+export {
+  ValidationError,
+  toValidationError,
+  isValidationError,
+  fromZodError,
+} from './ValidationError';

--- a/lib/sum.spec.ts
+++ b/lib/sum.spec.ts
@@ -1,5 +1,0 @@
-import { sum } from './sum';
-
-test('adds two numbers', async () => {
-  expect(sum(1, 1)).toEqual(2);
-});

--- a/lib/sum.ts
+++ b/lib/sum.ts
@@ -1,3 +1,0 @@
-export function sum(first: number, second: number): number {
-  return first + second;
-}

--- a/lib/utils/joinPath.test.ts
+++ b/lib/utils/joinPath.test.ts
@@ -1,0 +1,23 @@
+import { joinPath } from './joinPath';
+
+describe('joinPath()', () => {
+  test('handles empty path', () => {
+    expect(joinPath([])).toEqual('');
+  });
+
+  test('handles flat object path', () => {
+    expect(joinPath(['a'])).toEqual('a');
+  });
+
+  test('handles nested object path', () => {
+    expect(joinPath(['a', 'b', 'c'])).toEqual('a.b.c');
+  });
+
+  test('handles numeric index', () => {
+    expect(joinPath([0])).toEqual('[0]');
+  });
+
+  test('handles nested object path with numeric indices', () => {
+    expect(joinPath(['a', 0, 'b', 'c', 1, 2])).toEqual('a[0].b.c[1][2]');
+  });
+});

--- a/lib/utils/joinPath.ts
+++ b/lib/utils/joinPath.ts
@@ -1,0 +1,10 @@
+export function joinPath(arr: Array<string | number>): string {
+  return arr.reduce<string>((acc, value) => {
+    if (typeof value === 'number') {
+      return acc + '[' + value + ']';
+    }
+
+    const separator = acc === '' ? '' : '.';
+    return acc + separator + value;
+  }, '');
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
-  "name": "@causaly/typescript-pkg-template",
-  "version": "0.0.0",
-  "description": "Typescript package template",
+  "name": "@causaly/zod-validation-error",
+  "version": "0.1.0",
+  "description": "Wrap zod validation errors in user-friendly readable messages",
   "author": "Causaly Team <front-end@causaly.com>",
-  "license": "UNLICENSED",
-  "private": true,
-  "sideEffects": false,
+  "license": "MIT",
   "types": "./build/index.d.ts",
   "main": "./build/node/cjs/index.js",
   "exports": {
@@ -30,7 +28,7 @@
     "build": "rimraf build && concurrently \"tsc -p tsconfig.json\" \"yarn build:node-cjs\" \"yarn build:node-esm\" \"yarn build:browser-esm\"",
     "lint": "eslint lib --ext .ts",
     "format": "prettier --config ./.prettierrc --ignore-path .gitignore -w .",
-    "test": "jest --config jest.config.ts",
+    "test": "jest --config ./config/jest.config.ts",
     "coverage": "jest --config jest.config.ts --coverage",
     "changeset": "changeset",
     "prerelease": "yarn build && yarn test",
@@ -70,9 +68,11 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.0",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "zod": "^3.18.0"
   },
   "peerDependencies": {
-    "@swc/helpers": "^0.3.2"
+    "@swc/helpers": "^0.3.2",
+    "zod": "^3.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causaly/zod-validation-error",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Wrap zod validation errors in user-friendly readable messages",
   "author": "Causaly Team <front-end@causaly.com>",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4964,3 +4964,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.18.0:
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.18.0.tgz#2eed58b3cafb8d9a67aa2fee69279702f584f3bc"
+  integrity sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==


### PR DESCRIPTION
This PR is introducing a new `ValidationError` class alongside related functionality to convert `ZodError` to `ValidationError` and compose a user-friendly readable message.