### PR TITLE
Expose isValidationErrorLike type guard

### DIFF
--- a/.changeset/khaki-keys-smash.md
+++ b/.changeset/khaki-keys-smash.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': minor
+---
+
+Expose isValidationErrorLike type-guard

--- a/README.md
+++ b/README.md
@@ -77,6 +77,33 @@ Zod errors are difficult to consume for the end-user. This library wraps Zod val
 Validation error: Number must be greater than 0 at "id"; Invalid email at "email"
 ```
 
+## Guides and concepts
+
+### Type-guards
+
+`zod-validation-error` exposes two type-guard utilities that are used to indicate whether the supplied argument is a `ValidationError`.
+
+1. `isValidationError(err: unknown): err is ValidationError`
+2. `isValidationErrorLike(err: unknown): err is ValidationError`
+
+##### What is the difference?
+
+`isValidationError` is based on an `instanceof` comparison, whereas `isValidationErrorLike` is using a heuristics-based approach.
+
+> In most cases, it is recommended to use `isValidationErrorLike` to avoid multiple-version inconsistencies. For instance, it's possible that a dependency is using an older `zod-validation-error` version as a sub-dependency. In such case, the `instanceof` comparison will yield invalid results because the prototype is different with every module.
+
+#### Example
+
+```typescript
+import { ValidationError, isValidationErrorLike } from 'zod-validation-error';
+
+const err = new ValidationError('foobar', { details: [] });
+isValidationErrorLike(err); // returns true
+
+const invalidErr = new Error('foobar');
+isValidationErrorLike(err); // returns false
+```
+
 ## Contribute
 
 Source code contributions are most welcome. Please open a PR, ensure the linter is satisfied and all tests pass.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Validation error: Number must be greater than 0 at "id"; Invalid email at "email
 
 `isValidationError` is based on an `instanceof` comparison, whereas `isValidationErrorLike` is using a heuristics-based approach.
 
-> In most cases, it is recommended to use `isValidationErrorLike` to avoid multiple-version inconsistencies. For instance, it's possible that a dependency is using an older `zod-validation-error` version as a sub-dependency. In such case, the `instanceof` comparison will yield invalid results because the prototype is different with every module.
+> In most cases, it is recommended to use `isValidationErrorLike` to avoid multiple-version inconsistencies. For instance, it's possible that a dependency is using an older `zod-validation-error` version internally. In such case, the `instanceof` comparison will yield invalid results because module deduplication does not apply at npm/yarn level and the prototype is different.
 
 #### Example
 

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -4,6 +4,7 @@ import { ZodError } from 'zod';
 import {
   fromZodError,
   isValidationError,
+  isValidationErrorLike,
   ValidationError,
 } from './ValidationError';
 
@@ -211,6 +212,36 @@ describe('isValidationError()', () => {
     expect(isValidationError(123)).toEqual(false);
     expect(
       isValidationError({
+        message: 'foobar',
+      })
+    ).toEqual(false);
+  });
+});
+
+describe('isValidationErrorLike()', () => {
+  test('returns true when argument is an actual instance of ValidationError', () => {
+    expect(
+      isValidationErrorLike(new ValidationError('foobar', { details: [] }))
+    ).toEqual(true);
+  });
+
+  test('returns true when argument resembles a ValidationError', () => {
+    const err = new Error('foobar');
+    // @ts-ignore
+    err.type = 'ZodValidationError';
+
+    expect(isValidationErrorLike(err)).toEqual(true);
+  });
+
+  test('returns false when argument is generic Error', () => {
+    expect(isValidationErrorLike(new Error('foobar'))).toEqual(false);
+  });
+
+  test('returns false when argument is not an Error instance', () => {
+    expect(isValidationErrorLike('foobar')).toEqual(false);
+    expect(isValidationErrorLike(123)).toEqual(false);
+    expect(
+      isValidationErrorLike({
         message: 'foobar',
       })
     ).toEqual(false);

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -4,6 +4,7 @@ import { joinPath } from './utils/joinPath';
 
 export class ValidationError extends Error {
   details: Array<Zod.ZodIssue>;
+  type: 'ZodValidationError';
 
   constructor(
     message: string,
@@ -13,6 +14,7 @@ export class ValidationError extends Error {
   ) {
     super(message);
     this.details = options.details;
+    this.type = 'ZodValidationError';
   }
 }
 
@@ -71,4 +73,10 @@ export const toValidationError =
 
 export function isValidationError(err: unknown): err is ValidationError {
   return err instanceof ValidationError;
+}
+
+export function isValidationErrorLike(err: unknown): err is ValidationError {
+  return (
+    err instanceof Error && 'type' in err && err.type === 'ZodValidationError'
+  );
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,5 +2,6 @@ export {
   ValidationError,
   toValidationError,
   isValidationError,
+  isValidationErrorLike,
   fromZodError,
 } from './ValidationError';


### PR DESCRIPTION
Introduce a new type-guard based on heuristics instead of `instanceof` comparison to avoid multiple-version inconsistencies.