### PR TITLE
Flexible ValidationError

### DIFF
--- a/.changeset/tiny-kids-check.md
+++ b/.changeset/tiny-kids-check.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': major
+---
+
+Update ZodValidationError to behave more like a native Error constructor. Make options argument optional. Add name property and define toString() method.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Validation error: Number must be greater than 0 at "id"; Invalid email at "email
 
 ## API
 
-### `ValidationError(message, details)`
+### `ValidationError(message[, details])`
 
 Main `ValidationError` class, extending native JavaScript `Error`.
 
@@ -136,7 +136,7 @@ const invalidErr = new Error('foobar');
 isValidationErrorLike(err); // returns false
 ```
 
-### `fromZodError(zodError, options)`
+### `fromZodError(zodError[, options])`
 
 Converts zod error to `ValidationError`.
 
@@ -150,7 +150,7 @@ Converts zod error to `ValidationError`.
   - `prefix` - _string_; prefix in user-friendly message (optional, defaults to `Validation error`)
   - `prefixSeparator` - _string_; used to concatenate prefix with rest of the user-friendly message (optional, defaults to `: `)
 
-### `toValidationError(options) => (error) => ValidationError`
+### `toValidationError([options]) => (error) => ValidationError`
 
 A curried version of `fromZodError` meant to be used for FP (Functional Programming).
 

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -445,23 +445,29 @@ describe('isValidationErrorLike()', () => {
 describe('ValidationError', () => {
   describe('constructor', () => {
     test('accepts message with details', () => {
-      expect(
-        () =>
-          new ValidationError('Invalid email coyote@acme', [
-            {
-              code: 'invalid_string',
-              message: 'Invalid email',
-              path: [],
-              validation: 'email',
-            },
-          ])
-      ).not.toThrow();
+      const err = new ValidationError('Invalid email coyote@acme', [
+        {
+          code: 'invalid_string',
+          message: 'Invalid email',
+          path: [],
+          validation: 'email',
+        },
+      ]);
+      expect(err.details).toMatchInlineSnapshot(`
+        [
+          {
+            "code": "invalid_string",
+            "message": "Invalid email",
+            "path": [],
+            "validation": "email",
+          },
+        ]
+      `);
     });
 
     test('treats details as optional', () => {
-      expect(
-        () => new ValidationError('Invalid email coyote@acme')
-      ).not.toThrow();
+      const err = new ValidationError('Invalid email coyote@acme');
+      expect(err.details).toStrictEqual([]);
     });
   });
 

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -22,15 +22,15 @@ describe('fromZodError()', () => {
           `"Validation error: Invalid email"`
         );
         expect(validationError.details).toMatchInlineSnapshot(`
-        [
-          {
-            "code": "invalid_string",
-            "message": "Invalid email",
-            "path": [],
-            "validation": "email",
-          },
-        ]
-      `);
+                  [
+                    {
+                      "code": "invalid_string",
+                      "message": "Invalid email",
+                      "path": [],
+                      "validation": "email",
+                    },
+                  ]
+              `);
       }
     }
   });
@@ -54,31 +54,31 @@ describe('fromZodError()', () => {
           `"Validation error: Number must be greater than 0 at "id"; String must contain at least 2 character(s) at "name""`
         );
         expect(validationError.details).toMatchInlineSnapshot(`
-        [
-          {
-            "code": "too_small",
-            "exact": false,
-            "inclusive": false,
-            "message": "Number must be greater than 0",
-            "minimum": 0,
-            "path": [
-              "id",
-            ],
-            "type": "number",
-          },
-          {
-            "code": "too_small",
-            "exact": false,
-            "inclusive": true,
-            "message": "String must contain at least 2 character(s)",
-            "minimum": 2,
-            "path": [
-              "name",
-            ],
-            "type": "string",
-          },
-        ]
-      `);
+                  [
+                    {
+                      "code": "too_small",
+                      "exact": false,
+                      "inclusive": false,
+                      "message": "Number must be greater than 0",
+                      "minimum": 0,
+                      "path": [
+                        "id",
+                      ],
+                      "type": "number",
+                    },
+                    {
+                      "code": "too_small",
+                      "exact": false,
+                      "inclusive": true,
+                      "message": "String must contain at least 2 character(s)",
+                      "minimum": 2,
+                      "path": [
+                        "name",
+                      ],
+                      "type": "string",
+                    },
+                  ]
+              `);
       }
     }
   });
@@ -96,36 +96,36 @@ describe('fromZodError()', () => {
           `"Validation error: Expected number, received string at "[1]"; Expected number, received boolean at "[2]"; Expected integer, received float at "[3]""`
         );
         expect(validationError.details).toMatchInlineSnapshot(`
-        [
-          {
-            "code": "invalid_type",
-            "expected": "number",
-            "message": "Expected number, received string",
-            "path": [
-              1,
-            ],
-            "received": "string",
-          },
-          {
-            "code": "invalid_type",
-            "expected": "number",
-            "message": "Expected number, received boolean",
-            "path": [
-              2,
-            ],
-            "received": "boolean",
-          },
-          {
-            "code": "invalid_type",
-            "expected": "integer",
-            "message": "Expected integer, received float",
-            "path": [
-              3,
-            ],
-            "received": "float",
-          },
-        ]
-      `);
+                  [
+                    {
+                      "code": "invalid_type",
+                      "expected": "number",
+                      "message": "Expected number, received string",
+                      "path": [
+                        1,
+                      ],
+                      "received": "string",
+                    },
+                    {
+                      "code": "invalid_type",
+                      "expected": "number",
+                      "message": "Expected number, received boolean",
+                      "path": [
+                        2,
+                      ],
+                      "received": "boolean",
+                    },
+                    {
+                      "code": "invalid_type",
+                      "expected": "integer",
+                      "message": "Expected integer, received float",
+                      "path": [
+                        3,
+                      ],
+                      "received": "float",
+                    },
+                  ]
+              `);
       }
     }
   });
@@ -155,42 +155,42 @@ describe('fromZodError()', () => {
           `"Validation error: Number must be greater than 0 at "id"; Expected number, received string at "arr[1]"; String must contain at least 2 character(s) at "nestedObj.name""`
         );
         expect(validationError.details).toMatchInlineSnapshot(`
-        [
-          {
-            "code": "too_small",
-            "exact": false,
-            "inclusive": false,
-            "message": "Number must be greater than 0",
-            "minimum": 0,
-            "path": [
-              "id",
-            ],
-            "type": "number",
-          },
-          {
-            "code": "invalid_type",
-            "expected": "number",
-            "message": "Expected number, received string",
-            "path": [
-              "arr",
-              1,
-            ],
-            "received": "string",
-          },
-          {
-            "code": "too_small",
-            "exact": false,
-            "inclusive": true,
-            "message": "String must contain at least 2 character(s)",
-            "minimum": 2,
-            "path": [
-              "nestedObj",
-              "name",
-            ],
-            "type": "string",
-          },
-        ]
-      `);
+                  [
+                    {
+                      "code": "too_small",
+                      "exact": false,
+                      "inclusive": false,
+                      "message": "Number must be greater than 0",
+                      "minimum": 0,
+                      "path": [
+                        "id",
+                      ],
+                      "type": "number",
+                    },
+                    {
+                      "code": "invalid_type",
+                      "expected": "number",
+                      "message": "Expected number, received string",
+                      "path": [
+                        "arr",
+                        1,
+                      ],
+                      "received": "string",
+                    },
+                    {
+                      "code": "too_small",
+                      "exact": false,
+                      "inclusive": true,
+                      "message": "String must contain at least 2 character(s)",
+                      "minimum": 2,
+                      "path": [
+                        "nestedObj",
+                        "name",
+                      ],
+                      "type": "string",
+                    },
+                  ]
+              `);
       }
     }
   });
@@ -426,8 +426,7 @@ describe('isValidationErrorLike()', () => {
 
   test('returns true when argument resembles a ValidationError', () => {
     const err = new Error('foobar');
-    // @ts-ignore
-    err.type = 'ZodValidationError';
+    err.name = 'ZodValidationError'; // force ZodValidationError
 
     expect(isValidationErrorLike(err)).toEqual(true);
   });
@@ -444,5 +443,40 @@ describe('isValidationErrorLike()', () => {
         message: 'foobar',
       })
     ).toEqual(false);
+  });
+});
+
+describe('ValidationError', () => {
+  describe('constructor', () => {
+    test('accepts message', () => {
+      expect(
+        () => new ValidationError('Invalid email coyote@acme')
+      ).not.toThrow();
+    });
+
+    test('accepts message with details', () => {
+      expect(
+        () =>
+          new ValidationError('Invalid email coyote@acme', {
+            details: [
+              {
+                code: 'invalid_string',
+                message: 'Invalid email',
+                path: [],
+                validation: 'email',
+              },
+            ],
+          })
+      ).not.toThrow();
+    });
+  });
+
+  describe('toString()', () => {
+    test('converts error to string', () => {
+      const error = new ValidationError('Invalid email coyote@acme');
+      expect(error.toString()).toMatchInlineSnapshot(
+        `"Invalid email coyote@acme"`
+      );
+    });
   });
 });

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -397,9 +397,7 @@ describe('fromZodError()', () => {
 
 describe('isValidationError()', () => {
   test('returns true when argument is instance of ValidationError', () => {
-    expect(
-      isValidationError(new ValidationError('foobar', { details: [] }))
-    ).toEqual(true);
+    expect(isValidationError(new ValidationError('foobar'))).toEqual(true);
   });
 
   test('returns false when argument is plain Error', () => {
@@ -419,9 +417,7 @@ describe('isValidationError()', () => {
 
 describe('isValidationErrorLike()', () => {
   test('returns true when argument is an actual instance of ValidationError', () => {
-    expect(
-      isValidationErrorLike(new ValidationError('foobar', { details: [] }))
-    ).toEqual(true);
+    expect(isValidationErrorLike(new ValidationError('foobar'))).toEqual(true);
   });
 
   test('returns true when argument resembles a ValidationError', () => {
@@ -448,25 +444,23 @@ describe('isValidationErrorLike()', () => {
 
 describe('ValidationError', () => {
   describe('constructor', () => {
-    test('accepts message', () => {
-      expect(
-        () => new ValidationError('Invalid email coyote@acme')
-      ).not.toThrow();
-    });
-
     test('accepts message with details', () => {
       expect(
         () =>
-          new ValidationError('Invalid email coyote@acme', {
-            details: [
-              {
-                code: 'invalid_string',
-                message: 'Invalid email',
-                path: [],
-                validation: 'email',
-              },
-            ],
-          })
+          new ValidationError('Invalid email coyote@acme', [
+            {
+              code: 'invalid_string',
+              message: 'Invalid email',
+              path: [],
+              validation: 'email',
+            },
+          ])
+      ).not.toThrow();
+    });
+
+    test('treats details as optional', () => {
+      expect(
+        () => new ValidationError('Invalid email coyote@acme')
       ).not.toThrow();
     });
   });

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -6,14 +6,9 @@ export class ValidationError extends Error {
   details: Array<Zod.ZodIssue>;
   name: 'ZodValidationError';
 
-  constructor(
-    message: string,
-    options?: {
-      details: Array<Zod.ZodIssue>;
-    }
-  ) {
+  constructor(message: string, details: Array<Zod.ZodIssue> | undefined = []) {
     super(message);
-    this.details = options?.details ?? [];
+    this.details = details;
     this.name = 'ZodValidationError';
   }
 
@@ -78,9 +73,7 @@ export function fromZodError(
 
   const message = reason ? [prefix, reason].join(prefixSeparator) : prefix;
 
-  return new ValidationError(message, {
-    details: zodError.errors,
-  });
+  return new ValidationError(message, zodError.errors);
 }
 
 export const toValidationError =

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -4,17 +4,21 @@ import { joinPath } from './utils/joinPath';
 
 export class ValidationError extends Error {
   details: Array<Zod.ZodIssue>;
-  type: 'ZodValidationError';
+  name: 'ZodValidationError';
 
   constructor(
     message: string,
-    options: {
+    options?: {
       details: Array<Zod.ZodIssue>;
     }
   ) {
     super(message);
-    this.details = options.details;
-    this.type = 'ZodValidationError';
+    this.details = options?.details ?? [];
+    this.name = 'ZodValidationError';
+  }
+
+  toString(): string {
+    return this.message;
   }
 }
 
@@ -98,7 +102,5 @@ export function isValidationError(err: unknown): err is ValidationError {
 }
 
 export function isValidationErrorLike(err: unknown): err is ValidationError {
-  return (
-    err instanceof Error && 'type' in err && err.type === 'ZodValidationError'
-  );
+  return err instanceof Error && err.name === 'ZodValidationError';
 }


### PR DESCRIPTION
This PR implements the following changes...

1. Make `options` argument optional in `ValidationError` constructor, so as to enable a simple `new ValidationError('foobar');` invocation;
2. Use "name" instead of "type" to power the `isValidationErrorLike()` function. _Why?_ Because `name` is already defined in the Error spec (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name)
3. Overwrite `toString()` to avoid printing a `ZodValidationError: ` prefix on `console.log`