### PR TITLE
Increase coverage of JS identifiers in joinPath function

### DIFF
--- a/.changeset/wild-oranges-raise.md
+++ b/.changeset/wild-oranges-raise.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': minor
+---
+
+Handle unicode and special-character identifiers

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -10,10 +10,10 @@ import {
 
 describe('fromZodError()', () => {
   test('handles zod.string() schema errors', () => {
-    const emailSchema = zod.string().email();
+    const schema = zod.string().email();
 
     try {
-      emailSchema.parse('foobar');
+      schema.parse('foobar');
     } catch (err) {
       if (err instanceof ZodError) {
         const validationError = fromZodError(err);
@@ -36,13 +36,13 @@ describe('fromZodError()', () => {
   });
 
   test('handles zod.object() schema errors', () => {
-    const objSchema = zod.object({
+    const schema = zod.object({
       id: zod.number().int().positive(),
       name: zod.string().min(2),
     });
 
     try {
-      objSchema.parse({
+      schema.parse({
         id: -1,
         name: 'a',
       });
@@ -84,10 +84,10 @@ describe('fromZodError()', () => {
   });
 
   test('handles zod.array() schema errors', () => {
-    const objSchema = zod.array(zod.number().int());
+    const schema = zod.array(zod.number().int());
 
     try {
-      objSchema.parse([1, 'a', true, 1.23]);
+      schema.parse([1, 'a', true, 1.23]);
     } catch (err) {
       if (err instanceof ZodError) {
         const validationError = fromZodError(err);
@@ -131,7 +131,7 @@ describe('fromZodError()', () => {
   });
 
   test('handles nested zod.object() schema errors', () => {
-    const objSchema = zod.object({
+    const schema = zod.object({
       id: zod.number().int().positive(),
       arr: zod.array(zod.number().int()),
       nestedObj: zod.object({
@@ -140,7 +140,7 @@ describe('fromZodError()', () => {
     });
 
     try {
-      objSchema.parse({
+      schema.parse({
         id: -1,
         arr: [1, 'a'],
         nestedObj: {
@@ -196,12 +196,12 @@ describe('fromZodError()', () => {
   });
 
   test('schema.parse() path param to be part of error message', () => {
-    const objSchema = zod.object({
+    const schema = zod.object({
       status: zod.literal('success'),
     });
 
     try {
-      objSchema.parse(
+      schema.parse(
         {},
         {
           path: ['custom-path'],
@@ -243,10 +243,10 @@ describe('fromZodError()', () => {
       status: zod.literal('error'),
     });
 
-    const objSchema = success.or(error);
+    const schema = success.or(error);
 
     try {
-      objSchema.parse({});
+      schema.parse({});
     } catch (err) {
       if (err instanceof ZodError) {
         const validationError = fromZodError(err);
@@ -299,12 +299,12 @@ describe('fromZodError()', () => {
   });
 
   test('handles zod.or() schema duplicate errors', () => {
-    const objSchema = zod.object({
+    const schema = zod.object({
       terms: zod.array(zod.string()).or(zod.string()),
     });
 
     try {
-      objSchema.parse({});
+      schema.parse({});
     } catch (err) {
       if (err instanceof ZodError) {
         const validationError = fromZodError(err);
@@ -359,10 +359,10 @@ describe('fromZodError()', () => {
       prop2: zod.literal('value2'),
     });
 
-    const objSchema = part1.and(part2);
+    const schema = part1.and(part2);
 
     try {
-      objSchema.parse({});
+      schema.parse({});
     } catch (err) {
       if (err instanceof ZodError) {
         const validationError = fromZodError(err);

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -393,6 +393,50 @@ describe('fromZodError()', () => {
       }
     }
   });
+
+  test('handles special characters in property name', () => {
+    const schema = zod.object({
+      '.': zod.string(),
+      './*': zod.string(),
+    });
+
+    try {
+      schema.parse({
+        '.': 123,
+        './*': false,
+      });
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const validationError = fromZodError(err);
+        expect(validationError).toBeInstanceOf(ValidationError);
+        expect(validationError.message).toMatchInlineSnapshot(
+          `"Validation error: Expected string, received number at "["."]"; Expected string, received boolean at "["./*"]""`
+        );
+        expect(validationError.details).toMatchInlineSnapshot(`
+          [
+            {
+              "code": "invalid_type",
+              "expected": "string",
+              "message": "Expected string, received number",
+              "path": [
+                ".",
+              ],
+              "received": "number",
+            },
+            {
+              "code": "invalid_type",
+              "expected": "string",
+              "message": "Expected string, received boolean",
+              "path": [
+                "./*",
+              ],
+              "received": "boolean",
+            },
+          ]
+        `);
+      }
+    }
+  });
 });
 
 describe('isValidationError()', () => {

--- a/lib/utils/joinPath.test.ts
+++ b/lib/utils/joinPath.test.ts
@@ -13,11 +13,35 @@ describe('joinPath()', () => {
     expect(joinPath(['a', 'b', 'c'])).toEqual('a.b.c');
   });
 
+  test('handles ideograms', () => {
+    expect(joinPath(['你好'])).toEqual('你好');
+  });
+
+  test('handles nested object path with ideograms', () => {
+    expect(joinPath(['a', 'b', '你好'])).toEqual('a.b.你好');
+  });
+
   test('handles numeric index', () => {
     expect(joinPath([0])).toEqual('[0]');
   });
 
   test('handles nested object path with numeric indices', () => {
     expect(joinPath(['a', 0, 'b', 'c', 1, 2])).toEqual('a[0].b.c[1][2]');
+  });
+
+  test('handles special characters', () => {
+    expect(joinPath(['exports', './*'])).toEqual('exports["./*"]');
+  });
+
+  test('handles quote corner-case', () => {
+    expect(joinPath(['a', 'b', '"'])).toEqual('a.b["\\""]');
+  });
+
+  test('handles quoted values', () => {
+    expect(joinPath(['a', 'b', '"foo"'])).toEqual('a.b["\\"foo\\""]');
+  });
+
+  test('handles unicode characters', () => {
+    expect(joinPath(['a', 'b', '💩'])).toEqual('a.b["💩"]');
   });
 });

--- a/lib/utils/joinPath.ts
+++ b/lib/utils/joinPath.ts
@@ -1,10 +1,27 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
+ */
+const identifierRegex = /[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*/u;
+
 export function joinPath(arr: Array<string | number>): string {
   return arr.reduce<string>((acc, value) => {
+    // handle numeric indices
     if (typeof value === 'number') {
       return acc + '[' + value + ']';
     }
 
-    const separator = acc === '' ? '' : '.';
+    // handle quoted values
+    if (value.includes('"')) {
+      return acc + '["' + value.replace(/"/g, '\\"') + '"]';
+    }
+
+    // handle special characters
+    if (!identifierRegex.test(value)) {
+      return acc + '["' + value + '"]';
+    }
+
+    // handle normal values
+    const separator = acc.length === 0 ? '' : '.';
     return acc + separator + value;
   }, '');
 }


### PR DESCRIPTION
This PR updates the `joinPath` utility function to be able to handle unicode and special-char identifiers, according to spec (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers)

Fixes #18 