### PR TITLE
Better handling for single-item paths

### DIFF
--- a/.changeset/cyan-years-count.md
+++ b/.changeset/cyan-years-count.md
@@ -1,0 +1,9 @@
+---
+'zod-validation-error': major
+---
+
+Better handling for single-item paths
+
+Given a validation error at array position 1 the error output would read `Error X at "[1]"`. After this change, the error output reads `Error X at index 1`.
+
+Likewise, previously a validation error at property "_" would yield `Error X at "["_"]"`. Now it yields `Error X at "\*"` which reads much better.

--- a/lib/ValidationError.spec.ts
+++ b/lib/ValidationError.spec.ts
@@ -93,7 +93,7 @@ describe('fromZodError()', () => {
         const validationError = fromZodError(err);
         expect(validationError).toBeInstanceOf(ValidationError);
         expect(validationError.message).toMatchInlineSnapshot(
-          `"Validation error: Expected number, received string at "[1]"; Expected number, received boolean at "[2]"; Expected integer, received float at "[3]""`
+          `"Validation error: Expected number, received string at index 1; Expected number, received boolean at index 2; Expected integer, received float at index 3"`
         );
         expect(validationError.details).toMatchInlineSnapshot(`
                   [
@@ -410,7 +410,7 @@ describe('fromZodError()', () => {
         const validationError = fromZodError(err);
         expect(validationError).toBeInstanceOf(ValidationError);
         expect(validationError.message).toMatchInlineSnapshot(
-          `"Validation error: Expected string, received number at "["."]"; Expected string, received boolean at "["./*"]""`
+          `"Validation error: Expected string, received number at "."; Expected string, received boolean at "./*""`
         );
         expect(validationError.details).toMatchInlineSnapshot(`
           [

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -1,6 +1,7 @@
 import * as zod from 'zod';
 
 import { joinPath } from './utils/joinPath';
+import { isNonEmptyArray } from './utils/NonEmptyArray';
 
 export class ValidationError extends Error {
   details: Array<Zod.ZodIssue>;
@@ -38,7 +39,16 @@ function fromZodIssue(
       .join(unionSeparator);
   }
 
-  if (issue.path.length > 0) {
+  if (isNonEmptyArray(issue.path)) {
+    // handle array indices
+    if (issue.path.length === 1) {
+      const identifier = issue.path[0];
+
+      if (typeof identifier === 'number') {
+        return `${issue.message} at index ${identifier}`;
+      }
+    }
+
     return `${issue.message} at "${joinPath(issue.path)}"`;
   }
 

--- a/lib/utils/NonEmptyArray.ts
+++ b/lib/utils/NonEmptyArray.ts
@@ -1,0 +1,5 @@
+export type NonEmptyArray<T> = [T, ...T[]];
+
+export function isNonEmptyArray<T>(value: T[]): value is NonEmptyArray<T> {
+  return value.length !== 0;
+}

--- a/lib/utils/joinPath.test.ts
+++ b/lib/utils/joinPath.test.ts
@@ -1,10 +1,6 @@
 import { joinPath } from './joinPath';
 
 describe('joinPath()', () => {
-  test('handles empty path', () => {
-    expect(joinPath([])).toEqual('');
-  });
-
   test('handles flat object path', () => {
     expect(joinPath(['a'])).toEqual('a');
   });
@@ -22,7 +18,7 @@ describe('joinPath()', () => {
   });
 
   test('handles numeric index', () => {
-    expect(joinPath([0])).toEqual('[0]');
+    expect(joinPath([0])).toEqual('0');
   });
 
   test('handles nested object path with numeric indices', () => {

--- a/lib/utils/joinPath.ts
+++ b/lib/utils/joinPath.ts
@@ -1,27 +1,37 @@
+import { NonEmptyArray } from './NonEmptyArray';
+
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers
  */
 const identifierRegex = /[$_\p{ID_Start}][$\u200c\u200d\p{ID_Continue}]*/u;
 
-export function joinPath(arr: Array<string | number>): string {
-  return arr.reduce<string>((acc, value) => {
+export function joinPath(path: NonEmptyArray<string | number>): string {
+  if (path.length === 1) {
+    return path[0].toString();
+  }
+
+  return path.reduce<string>((acc, item) => {
     // handle numeric indices
-    if (typeof value === 'number') {
-      return acc + '[' + value + ']';
+    if (typeof item === 'number') {
+      return acc + '[' + item.toString() + ']';
     }
 
     // handle quoted values
-    if (value.includes('"')) {
-      return acc + '["' + value.replace(/"/g, '\\"') + '"]';
+    if (item.includes('"')) {
+      return acc + '["' + escapeQuotes(item) + '"]';
     }
 
     // handle special characters
-    if (!identifierRegex.test(value)) {
-      return acc + '["' + value + '"]';
+    if (!identifierRegex.test(item)) {
+      return acc + '["' + item + '"]';
     }
 
     // handle normal values
     const separator = acc.length === 0 ? '' : '.';
-    return acc + separator + value;
+    return acc + separator + item;
   }, '');
+}
+
+function escapeQuotes(str: string): string {
+  return str.replace(/"/g, '\\"');
 }


### PR DESCRIPTION
Before this PR, given a validation error at array position 1 the error output would read `Error X at "[1]"`. After this PR, the error output reads `Error X at index 1`.

The problem becomes more evident when you account for special characters. Previously a validation error at property "*" would yield `Error X at "["*"]"`. Now it yields `Error X at "*"` which reads much better.