### PR TITLE
Instruct dependabot to only update minor and patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: 'daily'
       time: '06:00'
       timezone: 'Europe/London'
+    groups:
+      default:
+        patterns:
+        - '*'
+        update-types:
+        - 'minor'
+        - 'patch'
     versioning-strategy: 'increase-if-necessary'
     commit-message:
       prefix: 'chore'


### PR DESCRIPTION
Major version upgrades often result to breaking the code, therefore we need to handle them separately via manual PRs.