### PR TITLE
Configure dependabot to ignore major version updates for all deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       time: '06:00'
       timezone: 'Europe/London'
     versioning-strategy: 'increase-if-necessary'
+    ignore:
+      # for all deps
+      - dependency-name: "*"
+        # ...ignore major updates
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: 'chore'
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,6 @@ updates:
       interval: 'daily'
       time: '06:00'
       timezone: 'Europe/London'
-    groups:
-      default:
-        patterns:
-        - '*'
-        update-types:
-        - 'minor'
-        - 'patch'
     versioning-strategy: 'increase-if-necessary'
     commit-message:
       prefix: 'chore'


### PR DESCRIPTION
The previous dependabot config wasn't working as anticipated. It was grouping several changes together. This is not the desired behaviour.

This PR configures dependabot to ignore major updates for all dependencies, while maintaining separate PRs for each update.