### PR TITLE
Refactor `ValidationError` to accept `ErrorOptions` as second parameter

### DIFF
--- a/.changeset/popular-suns-knock.md
+++ b/.changeset/popular-suns-knock.md
@@ -1,0 +1,39 @@
+---
+'zod-validation-error': major
+---
+
+BREAKING CHANGE: Refactor `ValidationError` to accept `ErrorOptions` as second parameter.
+
+What changed?
+
+Previously, `ValidationError` accepted `Array<ZodIssue>` as 2nd parameter. Now, it accepts `ErrorOptions` which contains a `cause` property. If `cause` is a `ZodError` then it will extract the attached issues and expose them over `error.details`.
+
+Why?
+
+This change allows us to use `ValidationError` like a native JavaScript [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error). For example, we can now do:
+
+```typescript
+import { ValidationError } from 'zod-validation-error';
+
+try {
+  // attempt to do something that might throw an error
+} catch (err) {
+  throw new ValidationError('Something went deeply wrong', { cause: err });
+}
+```
+
+How can you update your code?
+
+If you are using `ValidationError` directly, then you need to update your code to pass `ErrorOptions` as a 2nd parameter.
+
+```typescript
+import { ValidationError } from 'zod-validation-error';
+
+// before
+const err = new ValidationError('Something went wrong', zodError.issues);
+
+// after
+const err = new ValidationError('Something went wrong', { cause: zodError });
+```
+
+If you were never using `ValidationError` directly, then you don't need to do anything.

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Main `ValidationError` class, extending native JavaScript `Error`.
 #### Arguments
 
 - `message` - _string_; error message (required)
-- `options` - _ErrorOptions_; error options - see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#options) for further info (optional)
-  - `options.cause` - _ZodError_; original zod error or any other error (optional)
+- `options` - _ErrorOptions_; error options as per [JavaScript definition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#options) (optional)
+  - `options.cause` - _any_; can be used to hold the original zod error (optional)
 
 #### Example 1: construct new ValidationError with `message`
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ try {
   });
 } catch (err) {
   const validationError = fromZodError(err);
-  // the error now is readable by the user
+  // the error is now readable by the user
   // you may print it to console
-  // or return it via an API
-  console.log(validationError);
-  // and in case you want to get the actual error message
   console.log(validationError.toString());
+  // or return it as an actual error
+  return validationError;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,18 @@ const customErrorMap: zod.ZodErrorMap = (issue, ctx) => {
 zod.setErrorMap(customErrorMap);
 ```
 
+### How to use `zod-validation-error` with `react-hook-form`?
+
+```typescript
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { errorMap } from 'zod-validation-error';
+
+useForm({
+  resolver: zodResolver(schema, { errorMap }),
+});
+```
+
 ### Does `zod-validation-error` support CommonJS
 
 Yes, `zod-validation-error` supports CommonJS out-of-the-box. All you need to do is import it using `require`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Wrap zod validation errors in user-friendly readable messages.
 #### Features
 
 - User-friendly readable messages, configurable via options;
-- Maintain original issues under `error.issues`;
+- Maintain original issues under `error.details`;
 - Extensive tests.
 
 ## Installation
@@ -129,7 +129,7 @@ const error = new ValidationError('foobar', {
   ]),
 });
 
-console.log(error.issues); // prints issues from zod error
+console.log(error.details); // prints issues from zod error
 ```
 
 ### errorMap

--- a/lib/ValidationError.test.ts
+++ b/lib/ValidationError.test.ts
@@ -9,16 +9,19 @@ describe('ValidationError', () => {
 
       const err = new ValidationError(message);
       expect(err.message).toBe(message);
+      // @ts-ignore
+      expect(err.cause).toBeUndefined();
       expect(err.details).toEqual([]);
     });
 
     test('accepts message with cause', () => {
       const message = 'Invalid email coyote@acme';
+      const cause = new Error('foobar');
 
-      const err = new ValidationError(message, {
-        cause: new Error('foobar'),
-      });
+      const err = new ValidationError(message, { cause });
       expect(err.message).toBe(message);
+      // @ts-ignore
+      expect(err.cause).toEqual(cause);
       expect(err.details).toEqual([]);
     });
 
@@ -32,11 +35,14 @@ describe('ValidationError', () => {
           validation: 'email',
         },
       ];
+      const cause = new zod.ZodError(issues);
 
       const err = new ValidationError(message, {
-        cause: new zod.ZodError(issues),
+        cause,
       });
       expect(err.message).toBe(message);
+      // @ts-ignore
+      expect(err.cause).toEqual(cause);
       expect(err.details).toEqual(issues);
     });
   });

--- a/lib/ValidationError.test.ts
+++ b/lib/ValidationError.test.ts
@@ -9,7 +9,7 @@ describe('ValidationError', () => {
 
       const err = new ValidationError(message);
       expect(err.message).toBe(message);
-      expect(err.issues).toEqual([]);
+      expect(err.details).toEqual([]);
     });
 
     test('accepts message with cause', () => {
@@ -19,7 +19,7 @@ describe('ValidationError', () => {
         cause: new Error('foobar'),
       });
       expect(err.message).toBe(message);
-      expect(err.issues).toEqual([]);
+      expect(err.details).toEqual([]);
     });
 
     test('accepts ZodError as cause', () => {
@@ -37,7 +37,7 @@ describe('ValidationError', () => {
         cause: new zod.ZodError(issues),
       });
       expect(err.message).toBe(message);
-      expect(err.issues).toEqual(issues);
+      expect(err.details).toEqual(issues);
     });
   });
 

--- a/lib/ValidationError.test.ts
+++ b/lib/ValidationError.test.ts
@@ -1,0 +1,52 @@
+import * as zod from 'zod';
+
+import { ValidationError } from './ValidationError';
+
+describe('ValidationError', () => {
+  describe('constructor', () => {
+    test('accepts message', () => {
+      const message = 'Invalid email coyote@acme';
+
+      const err = new ValidationError(message);
+      expect(err.message).toBe(message);
+      expect(err.issues).toEqual([]);
+    });
+
+    test('accepts message with cause', () => {
+      const message = 'Invalid email coyote@acme';
+
+      const err = new ValidationError(message, {
+        cause: new Error('foobar'),
+      });
+      expect(err.message).toBe(message);
+      expect(err.issues).toEqual([]);
+    });
+
+    test('accepts ZodError as cause', () => {
+      const message = 'Invalid email coyote@acme';
+      const issues: Array<zod.ZodIssue> = [
+        {
+          code: 'invalid_string',
+          message: 'Invalid email',
+          path: [],
+          validation: 'email',
+        },
+      ];
+
+      const err = new ValidationError(message, {
+        cause: new zod.ZodError(issues),
+      });
+      expect(err.message).toBe(message);
+      expect(err.issues).toEqual(issues);
+    });
+  });
+
+  describe('toString()', () => {
+    test('converts error to string', () => {
+      const error = new ValidationError('Invalid email coyote@acme');
+      expect(error.toString()).toMatchInlineSnapshot(
+        `"Invalid email coyote@acme"`
+      );
+    });
+  });
+});

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -1,25 +1,13 @@
 import * as zod from 'zod';
 
-import { joinPath } from './utils/joinPath';
-import { isNonEmptyArray } from './utils/NonEmptyArray';
-
-const MAX_ISSUES_IN_MESSAGE = 99; // I've got 99 problems but the b$tch ain't one
-const ISSUE_SEPARATOR = '; ';
-const UNION_SEPARATOR = ', or ';
-const PREFIX = 'Validation error';
-const PREFIX_SEPARATOR = ': ';
-
-export type ZodError = zod.ZodError;
-export type ZodIssue = zod.ZodIssue;
-
 export class ValidationError extends Error {
-  details: Array<zod.ZodIssue>;
   name: 'ZodValidationError';
+  issues: Array<zod.ZodIssue>;
 
-  constructor(message: string, details: Array<zod.ZodIssue> | undefined = []) {
-    super(message);
-    this.details = details;
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'ZodValidationError';
+    this.issues = getIssuesFromErrorOptions(options);
   }
 
   toString(): string {
@@ -27,174 +15,16 @@ export class ValidationError extends Error {
   }
 }
 
-function getMessageFromZodIssue(props: {
-  issue: ZodIssue;
-  issueSeparator: string;
-  unionSeparator: string;
-  includePath: boolean;
-}): string {
-  const { issue, issueSeparator, unionSeparator, includePath } = props;
+function getIssuesFromErrorOptions(
+  options?: ErrorOptions
+): Array<zod.ZodIssue> {
+  if (options) {
+    const cause = options.cause;
 
-  if (issue.code === 'invalid_union') {
-    return issue.unionErrors
-      .reduce<string[]>((acc, zodError) => {
-        const newIssues = zodError.issues
-          .map((issue) =>
-            getMessageFromZodIssue({
-              issue,
-              issueSeparator,
-              unionSeparator,
-              includePath,
-            })
-          )
-          .join(issueSeparator);
-
-        if (!acc.includes(newIssues)) {
-          acc.push(newIssues);
-        }
-
-        return acc;
-      }, [])
-      .join(unionSeparator);
+    if (cause instanceof zod.ZodError) {
+      return cause.issues;
+    }
   }
 
-  if (includePath && isNonEmptyArray(issue.path)) {
-    // handle array indices
-    if (issue.path.length === 1) {
-      const identifier = issue.path[0];
-
-      if (typeof identifier === 'number') {
-        return `${issue.message} at index ${identifier}`;
-      }
-    }
-
-    return `${issue.message} at "${joinPath(issue.path)}"`;
-  }
-
-  return issue.message;
+  return [];
 }
-
-function conditionallyPrefixMessage(
-  reason: string,
-  prefix: string | null,
-  prefixSeparator: string
-): string {
-  if (prefix !== null) {
-    if (reason.length > 0) {
-      return [prefix, reason].join(prefixSeparator);
-    }
-
-    return prefix;
-  }
-
-  if (reason.length > 0) {
-    return reason;
-  }
-
-  // if both reason and prefix are empty, return default prefix
-  // to avoid having an empty error message
-  return PREFIX;
-}
-
-export type FromZodIssueOptions = {
-  issueSeparator?: string;
-  unionSeparator?: string;
-  prefix?: string | null;
-  prefixSeparator?: string;
-  includePath?: boolean;
-};
-
-export function fromZodIssue(
-  issue: ZodIssue,
-  options: FromZodIssueOptions = {}
-): ValidationError {
-  const {
-    issueSeparator = ISSUE_SEPARATOR,
-    unionSeparator = UNION_SEPARATOR,
-    prefixSeparator = PREFIX_SEPARATOR,
-    prefix = PREFIX,
-    includePath = true,
-  } = options;
-
-  const reason = getMessageFromZodIssue({
-    issue,
-    issueSeparator,
-    unionSeparator,
-    includePath,
-  });
-  const message = conditionallyPrefixMessage(reason, prefix, prefixSeparator);
-
-  return new ValidationError(message, [issue]);
-}
-
-export type FromZodErrorOptions = FromZodIssueOptions & {
-  maxIssuesInMessage?: number;
-};
-
-export function fromZodError(
-  zodError: ZodError,
-  options: FromZodErrorOptions = {}
-): ValidationError {
-  const {
-    maxIssuesInMessage = MAX_ISSUES_IN_MESSAGE,
-    issueSeparator = ISSUE_SEPARATOR,
-    unionSeparator = UNION_SEPARATOR,
-    prefixSeparator = PREFIX_SEPARATOR,
-    prefix = PREFIX,
-    includePath = true,
-  } = options;
-
-  const reason = zodError.errors
-    // limit max number of issues printed in the reason section
-    .slice(0, maxIssuesInMessage)
-    // format error message
-    .map((issue) =>
-      getMessageFromZodIssue({
-        issue,
-        issueSeparator,
-        unionSeparator,
-        includePath,
-      })
-    )
-    // concat as string
-    .join(issueSeparator);
-
-  const message = conditionallyPrefixMessage(reason, prefix, prefixSeparator);
-
-  return new ValidationError(message, zodError.errors);
-}
-
-export const toValidationError =
-  (options: Parameters<typeof fromZodError>[1] = {}) =>
-  (err: unknown): ValidationError => {
-    if (err instanceof zod.ZodError) {
-      return fromZodError(err, options);
-    }
-
-    if (err instanceof Error) {
-      return new ValidationError(err.message);
-    }
-
-    return new ValidationError('Unknown error');
-  };
-
-export function isValidationError(err: unknown): err is ValidationError {
-  return err instanceof ValidationError;
-}
-
-export function isValidationErrorLike(err: unknown): err is ValidationError {
-  return err instanceof Error && err.name === 'ZodValidationError';
-}
-
-export const errorMap: zod.ZodErrorMap = (issue, ctx) => {
-  const error = fromZodIssue({
-    ...issue,
-    // fallback to the default error message
-    // when issue does not have a message
-    message: issue.message ?? ctx.defaultError,
-  });
-
-  return {
-    message: error.message,
-  };
-};

--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -2,12 +2,12 @@ import * as zod from 'zod';
 
 export class ValidationError extends Error {
   name: 'ZodValidationError';
-  issues: Array<zod.ZodIssue>;
+  details: Array<zod.ZodIssue>;
 
   constructor(message?: string, options?: ErrorOptions) {
     super(message, options);
     this.name = 'ZodValidationError';
-    this.issues = getIssuesFromErrorOptions(options);
+    this.details = getIssuesFromErrorOptions(options);
   }
 
   toString(): string {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,5 @@
+export const ISSUE_SEPARATOR = '; ';
+export const MAX_ISSUES_IN_MESSAGE = 99; // I've got 99 problems but the b$tch ain't one
+export const PREFIX = 'Validation error';
+export const PREFIX_SEPARATOR = ': ';
+export const UNION_SEPARATOR = ', or ';

--- a/lib/errorMap.ts
+++ b/lib/errorMap.ts
@@ -1,0 +1,16 @@
+import * as zod from 'zod';
+
+import { fromZodIssue } from './fromZodIssue';
+
+export const errorMap: zod.ZodErrorMap = (issue, ctx) => {
+  const error = fromZodIssue({
+    ...issue,
+    // fallback to the default error message
+    // when issue does not have a message
+    message: issue.message ?? ctx.defaultError,
+  });
+
+  return {
+    message: error.message,
+  };
+};

--- a/lib/fromZodError.test.ts
+++ b/lib/fromZodError.test.ts
@@ -1,61 +1,8 @@
 import * as zod from 'zod';
 import { ZodError } from 'zod';
 
-import {
-  fromZodError,
-  fromZodIssue,
-  isValidationError,
-  isValidationErrorLike,
-  ValidationError,
-} from './ValidationError';
-
-describe('fromZodIssue()', () => {
-  test('handles zod.string() schema errors', () => {
-    const schema = zod.string().email();
-
-    try {
-      schema.parse('foobar');
-    } catch (err) {
-      if (err instanceof ZodError) {
-        const validationError = fromZodIssue(err.issues[0]);
-        expect(validationError).toBeInstanceOf(ValidationError);
-        expect(validationError.message).toMatchInlineSnapshot(
-          `"Validation error: Invalid email"`
-        );
-        expect(validationError.details).toMatchInlineSnapshot(`
-                  [
-                    {
-                      "code": "invalid_string",
-                      "message": "Invalid email",
-                      "path": [],
-                      "validation": "email",
-                    },
-                  ]
-              `);
-      }
-    }
-  });
-
-  test('respects `includePath` prop when set to `false`', () => {
-    const schema = zod.object({
-      name: zod.string().min(3, '"Name" must be at least 3 characters'),
-    });
-
-    try {
-      schema.parse({ name: 'jo' });
-    } catch (err) {
-      if (err instanceof ZodError) {
-        const validationError = fromZodIssue(err.issues[0], {
-          includePath: false,
-        });
-        expect(validationError).toBeInstanceOf(ValidationError);
-        expect(validationError.message).toMatchInlineSnapshot(
-          `"Validation error: "Name" must be at least 3 characters"`
-        );
-      }
-    }
-  });
-});
+import { fromZodError } from './fromZodError';
+import { ValidationError } from './ValidationError';
 
 describe('fromZodError()', () => {
   test('handles zod.string() schema errors', () => {
@@ -70,16 +17,16 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid email"`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
-                  [
-                    {
-                      "code": "invalid_string",
-                      "message": "Invalid email",
-                      "path": [],
-                      "validation": "email",
-                    },
-                  ]
-              `);
+        expect(validationError.issues).toMatchInlineSnapshot(`
+            [
+              {
+                "code": "invalid_string",
+                "message": "Invalid email",
+                "path": [],
+                "validation": "email",
+              },
+            ]
+        `);
       }
     }
   });
@@ -102,32 +49,32 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Number must be greater than 0 at "id"; String must contain at least 2 character(s) at "name""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
-                  [
-                    {
-                      "code": "too_small",
-                      "exact": false,
-                      "inclusive": false,
-                      "message": "Number must be greater than 0",
-                      "minimum": 0,
-                      "path": [
-                        "id",
-                      ],
-                      "type": "number",
-                    },
-                    {
-                      "code": "too_small",
-                      "exact": false,
-                      "inclusive": true,
-                      "message": "String must contain at least 2 character(s)",
-                      "minimum": 2,
-                      "path": [
-                        "name",
-                      ],
-                      "type": "string",
-                    },
-                  ]
-              `);
+        expect(validationError.issues).toMatchInlineSnapshot(`
+          [
+            {
+              "code": "too_small",
+              "exact": false,
+              "inclusive": false,
+              "message": "Number must be greater than 0",
+              "minimum": 0,
+              "path": [
+                "id",
+              ],
+              "type": "number",
+            },
+            {
+              "code": "too_small",
+              "exact": false,
+              "inclusive": true,
+              "message": "String must contain at least 2 character(s)",
+              "minimum": 2,
+              "path": [
+                "name",
+              ],
+              "type": "string",
+            },
+          ]
+      `);
       }
     }
   });
@@ -144,37 +91,37 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Expected number, received string at index 1; Expected number, received boolean at index 2; Expected integer, received float at index 3"`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
-                  [
-                    {
-                      "code": "invalid_type",
-                      "expected": "number",
-                      "message": "Expected number, received string",
-                      "path": [
-                        1,
-                      ],
-                      "received": "string",
-                    },
-                    {
-                      "code": "invalid_type",
-                      "expected": "number",
-                      "message": "Expected number, received boolean",
-                      "path": [
-                        2,
-                      ],
-                      "received": "boolean",
-                    },
-                    {
-                      "code": "invalid_type",
-                      "expected": "integer",
-                      "message": "Expected integer, received float",
-                      "path": [
-                        3,
-                      ],
-                      "received": "float",
-                    },
-                  ]
-              `);
+        expect(validationError.issues).toMatchInlineSnapshot(`
+            [
+              {
+                "code": "invalid_type",
+                "expected": "number",
+                "message": "Expected number, received string",
+                "path": [
+                  1,
+                ],
+                "received": "string",
+              },
+              {
+                "code": "invalid_type",
+                "expected": "number",
+                "message": "Expected number, received boolean",
+                "path": [
+                  2,
+                ],
+                "received": "boolean",
+              },
+              {
+                "code": "invalid_type",
+                "expected": "integer",
+                "message": "Expected integer, received float",
+                "path": [
+                  3,
+                ],
+                "received": "float",
+              },
+            ]
+        `);
       }
     }
   });
@@ -203,43 +150,43 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Number must be greater than 0 at "id"; Expected number, received string at "arr[1]"; String must contain at least 2 character(s) at "nestedObj.name""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
-                  [
-                    {
-                      "code": "too_small",
-                      "exact": false,
-                      "inclusive": false,
-                      "message": "Number must be greater than 0",
-                      "minimum": 0,
-                      "path": [
-                        "id",
-                      ],
-                      "type": "number",
-                    },
-                    {
-                      "code": "invalid_type",
-                      "expected": "number",
-                      "message": "Expected number, received string",
-                      "path": [
-                        "arr",
-                        1,
-                      ],
-                      "received": "string",
-                    },
-                    {
-                      "code": "too_small",
-                      "exact": false,
-                      "inclusive": true,
-                      "message": "String must contain at least 2 character(s)",
-                      "minimum": 2,
-                      "path": [
-                        "nestedObj",
-                        "name",
-                      ],
-                      "type": "string",
-                    },
-                  ]
-              `);
+        expect(validationError.issues).toMatchInlineSnapshot(`
+            [
+              {
+                "code": "too_small",
+                "exact": false,
+                "inclusive": false,
+                "message": "Number must be greater than 0",
+                "minimum": 0,
+                "path": [
+                  "id",
+                ],
+                "type": "number",
+              },
+              {
+                "code": "invalid_type",
+                "expected": "number",
+                "message": "Expected number, received string",
+                "path": [
+                  "arr",
+                  1,
+                ],
+                "received": "string",
+              },
+              {
+                "code": "too_small",
+                "exact": false,
+                "inclusive": true,
+                "message": "String must contain at least 2 character(s)",
+                "minimum": 2,
+                "path": [
+                  "nestedObj",
+                  "name",
+                ],
+                "type": "string",
+              },
+            ]
+        `);
       }
     }
   });
@@ -263,7 +210,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid literal value, expected "success" at "custom-path.status""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
+        expect(validationError.issues).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_literal",
@@ -304,7 +251,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid literal value, expected "success" at "status"; Required at "data", or Invalid literal value, expected "error" at "status""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
+        expect(validationError.issues).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_union",
@@ -362,7 +309,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Required at "terms""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
+        expect(validationError.issues).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_union",
@@ -420,7 +367,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid literal value, expected "value1" at "prop1"; Invalid literal value, expected "value2" at "prop2""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
+        expect(validationError.issues).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_literal",
@@ -464,7 +411,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Expected string, received number at "."; Expected string, received boolean at "./*""`
         );
-        expect(validationError.details).toMatchInlineSnapshot(`
+        expect(validationError.issues).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_type",
@@ -506,91 +453,5 @@ describe('fromZodError()', () => {
         );
       }
     }
-  });
-});
-
-describe('isValidationError()', () => {
-  test('returns true when argument is instance of ValidationError', () => {
-    expect(isValidationError(new ValidationError('foobar'))).toEqual(true);
-  });
-
-  test('returns false when argument is plain Error', () => {
-    expect(isValidationError(new Error('foobar'))).toEqual(false);
-  });
-
-  test('returns false when argument is not an Error', () => {
-    expect(isValidationError('foobar')).toEqual(false);
-    expect(isValidationError(123)).toEqual(false);
-    expect(
-      isValidationError({
-        message: 'foobar',
-      })
-    ).toEqual(false);
-  });
-});
-
-describe('isValidationErrorLike()', () => {
-  test('returns true when argument is an actual instance of ValidationError', () => {
-    expect(isValidationErrorLike(new ValidationError('foobar'))).toEqual(true);
-  });
-
-  test('returns true when argument resembles a ValidationError', () => {
-    const err = new Error('foobar');
-    err.name = 'ZodValidationError'; // force ZodValidationError
-
-    expect(isValidationErrorLike(err)).toEqual(true);
-  });
-
-  test('returns false when argument is generic Error', () => {
-    expect(isValidationErrorLike(new Error('foobar'))).toEqual(false);
-  });
-
-  test('returns false when argument is not an Error instance', () => {
-    expect(isValidationErrorLike('foobar')).toEqual(false);
-    expect(isValidationErrorLike(123)).toEqual(false);
-    expect(
-      isValidationErrorLike({
-        message: 'foobar',
-      })
-    ).toEqual(false);
-  });
-});
-
-describe('ValidationError', () => {
-  describe('constructor', () => {
-    test('accepts message with details', () => {
-      const err = new ValidationError('Invalid email coyote@acme', [
-        {
-          code: 'invalid_string',
-          message: 'Invalid email',
-          path: [],
-          validation: 'email',
-        },
-      ]);
-      expect(err.details).toMatchInlineSnapshot(`
-        [
-          {
-            "code": "invalid_string",
-            "message": "Invalid email",
-            "path": [],
-            "validation": "email",
-          },
-        ]
-      `);
-    });
-
-    test('treats details as optional', () => {
-      const err = new ValidationError('Invalid email coyote@acme');
-      expect(err.details).toStrictEqual([]);
-    });
-  });
-
-  describe('toString()', () => {
-    test('converts error to string', () => {
-      const error = new ValidationError('Invalid email coyote@acme');
-      expect(error.toString()).toMatchInlineSnapshot(
-        `"Invalid email coyote@acme"`
-      );
-    });
   });
 });

--- a/lib/fromZodError.test.ts
+++ b/lib/fromZodError.test.ts
@@ -17,7 +17,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid email"`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
             [
               {
                 "code": "invalid_string",
@@ -49,7 +49,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Number must be greater than 0 at "id"; String must contain at least 2 character(s) at "name""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
           [
             {
               "code": "too_small",
@@ -91,7 +91,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Expected number, received string at index 1; Expected number, received boolean at index 2; Expected integer, received float at index 3"`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
             [
               {
                 "code": "invalid_type",
@@ -150,7 +150,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Number must be greater than 0 at "id"; Expected number, received string at "arr[1]"; String must contain at least 2 character(s) at "nestedObj.name""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
             [
               {
                 "code": "too_small",
@@ -210,7 +210,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid literal value, expected "success" at "custom-path.status""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_literal",
@@ -251,7 +251,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid literal value, expected "success" at "status"; Required at "data", or Invalid literal value, expected "error" at "status""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_union",
@@ -309,7 +309,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Required at "terms""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_union",
@@ -367,7 +367,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid literal value, expected "value1" at "prop1"; Invalid literal value, expected "value2" at "prop2""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_literal",
@@ -411,7 +411,7 @@ describe('fromZodError()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Expected string, received number at "."; Expected string, received boolean at "./*""`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
           [
             {
               "code": "invalid_type",

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -1,0 +1,59 @@
+import * as zod from 'zod';
+
+import {
+  ISSUE_SEPARATOR,
+  MAX_ISSUES_IN_MESSAGE,
+  PREFIX,
+  PREFIX_SEPARATOR,
+  UNION_SEPARATOR,
+} from './config';
+import {
+  conditionallyPrefixMessage,
+  FromZodIssueOptions,
+  getMessageFromZodIssue,
+} from './fromZodIssue';
+import { ValidationError } from './ValidationError';
+
+export type ZodError = zod.ZodError;
+
+export type FromZodErrorOptions = FromZodIssueOptions & {
+  maxIssuesInMessage?: number;
+};
+
+export function fromZodError(
+  zodError: ZodError,
+  options: FromZodErrorOptions = {}
+): ValidationError {
+  const {
+    maxIssuesInMessage = MAX_ISSUES_IN_MESSAGE,
+    issueSeparator = ISSUE_SEPARATOR,
+    unionSeparator = UNION_SEPARATOR,
+    prefixSeparator = PREFIX_SEPARATOR,
+    prefix = PREFIX,
+    includePath = true,
+  } = options;
+
+  const zodIssues = zodError.errors || [];
+
+  const reason =
+    zodIssues.length === 0
+      ? zodError.message
+      : zodIssues
+          // limit max number of issues printed in the reason section
+          .slice(0, maxIssuesInMessage)
+          // format error message
+          .map((issue) =>
+            getMessageFromZodIssue({
+              issue,
+              issueSeparator,
+              unionSeparator,
+              includePath,
+            })
+          )
+          // concat as string
+          .join(issueSeparator);
+
+  const message = conditionallyPrefixMessage(reason, prefix, prefixSeparator);
+
+  return new ValidationError(message, { cause: zodError });
+}

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -7,11 +7,8 @@ import {
   PREFIX_SEPARATOR,
   UNION_SEPARATOR,
 } from './config';
-import {
-  conditionallyPrefixMessage,
-  FromZodIssueOptions,
-  getMessageFromZodIssue,
-} from './fromZodIssue';
+import { FromZodIssueOptions, getMessageFromZodIssue } from './fromZodIssue';
+import { prefixMessage } from './prefixMessage';
 import { ValidationError } from './ValidationError';
 
 export type ZodError = zod.ZodError;
@@ -53,7 +50,7 @@ export function fromZodError(
           // concat as string
           .join(issueSeparator);
 
-  const message = conditionallyPrefixMessage(reason, prefix, prefixSeparator);
+  const message = prefixMessage(reason, prefix, prefixSeparator);
 
   return new ValidationError(message, { cause: zodError });
 }

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -33,7 +33,7 @@ export function fromZodError(
     includePath = true,
   } = options;
 
-  const zodIssues = zodError.errors || [];
+  const zodIssues = zodError.errors;
 
   const reason =
     zodIssues.length === 0

--- a/lib/fromZodIssue.test.ts
+++ b/lib/fromZodIssue.test.ts
@@ -16,7 +16,7 @@ describe('fromZodIssue()', () => {
         expect(validationError.message).toMatchInlineSnapshot(
           `"Validation error: Invalid email"`
         );
-        expect(validationError.issues).toMatchInlineSnapshot(`
+        expect(validationError.details).toMatchInlineSnapshot(`
             [
               {
                 "code": "invalid_string",

--- a/lib/fromZodIssue.test.ts
+++ b/lib/fromZodIssue.test.ts
@@ -1,0 +1,52 @@
+import * as zod from 'zod';
+
+import { fromZodIssue } from './fromZodIssue';
+import { ValidationError } from './ValidationError';
+
+describe('fromZodIssue()', () => {
+  test('handles zod.string() schema errors', () => {
+    const schema = zod.string().email();
+
+    try {
+      schema.parse('foobar');
+    } catch (err) {
+      if (err instanceof zod.ZodError) {
+        const validationError = fromZodIssue(err.issues[0]);
+        expect(validationError).toBeInstanceOf(ValidationError);
+        expect(validationError.message).toMatchInlineSnapshot(
+          `"Validation error: Invalid email"`
+        );
+        expect(validationError.issues).toMatchInlineSnapshot(`
+            [
+              {
+                "code": "invalid_string",
+                "message": "Invalid email",
+                "path": [],
+                "validation": "email",
+              },
+            ]
+        `);
+      }
+    }
+  });
+
+  test('respects `includePath` prop when set to `false`', () => {
+    const schema = zod.object({
+      name: zod.string().min(3, '"Name" must be at least 3 characters'),
+    });
+
+    try {
+      schema.parse({ name: 'jo' });
+    } catch (err) {
+      if (err instanceof zod.ZodError) {
+        const validationError = fromZodIssue(err.issues[0], {
+          includePath: false,
+        });
+        expect(validationError).toBeInstanceOf(ValidationError);
+        expect(validationError.message).toMatchInlineSnapshot(
+          `"Validation error: "Name" must be at least 3 characters"`
+        );
+      }
+    }
+  });
+});

--- a/lib/fromZodIssue.ts
+++ b/lib/fromZodIssue.ts
@@ -1,0 +1,113 @@
+import * as zod from 'zod';
+
+import {
+  ISSUE_SEPARATOR,
+  PREFIX,
+  PREFIX_SEPARATOR,
+  UNION_SEPARATOR,
+} from './config';
+import { joinPath } from './utils/joinPath';
+import { isNonEmptyArray } from './utils/NonEmptyArray';
+import { ValidationError } from './ValidationError';
+
+export type ZodIssue = zod.ZodIssue;
+
+export function getMessageFromZodIssue(props: {
+  issue: ZodIssue;
+  issueSeparator: string;
+  unionSeparator: string;
+  includePath: boolean;
+}): string {
+  const { issue, issueSeparator, unionSeparator, includePath } = props;
+
+  if (issue.code === 'invalid_union') {
+    return issue.unionErrors
+      .reduce<string[]>((acc, zodError) => {
+        const newIssues = zodError.issues
+          .map((issue) =>
+            getMessageFromZodIssue({
+              issue,
+              issueSeparator,
+              unionSeparator,
+              includePath,
+            })
+          )
+          .join(issueSeparator);
+
+        if (!acc.includes(newIssues)) {
+          acc.push(newIssues);
+        }
+
+        return acc;
+      }, [])
+      .join(unionSeparator);
+  }
+
+  if (includePath && isNonEmptyArray(issue.path)) {
+    // handle array indices
+    if (issue.path.length === 1) {
+      const identifier = issue.path[0];
+
+      if (typeof identifier === 'number') {
+        return `${issue.message} at index ${identifier}`;
+      }
+    }
+
+    return `${issue.message} at "${joinPath(issue.path)}"`;
+  }
+
+  return issue.message;
+}
+
+export function conditionallyPrefixMessage(
+  reason: string,
+  prefix: string | null,
+  prefixSeparator: string
+): string {
+  if (prefix !== null) {
+    if (reason.length > 0) {
+      return [prefix, reason].join(prefixSeparator);
+    }
+
+    return prefix;
+  }
+
+  if (reason.length > 0) {
+    return reason;
+  }
+
+  // if both reason and prefix are empty, return default prefix
+  // to avoid having an empty error message
+  return PREFIX;
+}
+
+export type FromZodIssueOptions = {
+  issueSeparator?: string;
+  unionSeparator?: string;
+  prefix?: string | null;
+  prefixSeparator?: string;
+  includePath?: boolean;
+};
+
+export function fromZodIssue(
+  issue: ZodIssue,
+  options: FromZodIssueOptions = {}
+): ValidationError {
+  const {
+    issueSeparator = ISSUE_SEPARATOR,
+    unionSeparator = UNION_SEPARATOR,
+    prefixSeparator = PREFIX_SEPARATOR,
+    prefix = PREFIX,
+    includePath = true,
+  } = options;
+
+  const reason = getMessageFromZodIssue({
+    issue,
+    issueSeparator,
+    unionSeparator,
+    includePath,
+  });
+  const message = conditionallyPrefixMessage(reason, prefix, prefixSeparator);
+
+  return new ValidationError(message, { cause: new zod.ZodError([issue]) });
+}

--- a/lib/fromZodIssue.ts
+++ b/lib/fromZodIssue.ts
@@ -6,6 +6,7 @@ import {
   PREFIX_SEPARATOR,
   UNION_SEPARATOR,
 } from './config';
+import { prefixMessage } from './prefixMessage';
 import { joinPath } from './utils/joinPath';
 import { isNonEmptyArray } from './utils/NonEmptyArray';
 import { ValidationError } from './ValidationError';
@@ -59,28 +60,6 @@ export function getMessageFromZodIssue(props: {
   return issue.message;
 }
 
-export function conditionallyPrefixMessage(
-  reason: string,
-  prefix: string | null,
-  prefixSeparator: string
-): string {
-  if (prefix !== null) {
-    if (reason.length > 0) {
-      return [prefix, reason].join(prefixSeparator);
-    }
-
-    return prefix;
-  }
-
-  if (reason.length > 0) {
-    return reason;
-  }
-
-  // if both reason and prefix are empty, return default prefix
-  // to avoid having an empty error message
-  return PREFIX;
-}
-
 export type FromZodIssueOptions = {
   issueSeparator?: string;
   unionSeparator?: string;
@@ -107,7 +86,7 @@ export function fromZodIssue(
     unionSeparator,
     includePath,
   });
-  const message = conditionallyPrefixMessage(reason, prefix, prefixSeparator);
+  const message = prefixMessage(reason, prefix, prefixSeparator);
 
   return new ValidationError(message, { cause: new zod.ZodError([issue]) });
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,15 @@
+export { ValidationError } from './ValidationError';
+export { isValidationError } from './isValidationError';
+export { isValidationErrorLike } from './isValidationErrorLike';
+export { errorMap } from './errorMap';
 export {
-  ValidationError,
-  toValidationError,
-  isValidationError,
-  isValidationErrorLike,
-  fromZodError,
   fromZodIssue,
-  type ZodError,
-  type ZodIssue,
-  type FromZodErrorOptions,
   type FromZodIssueOptions,
-  errorMap,
-} from './ValidationError';
+  type ZodIssue,
+} from './fromZodIssue';
+export {
+  fromZodError,
+  type FromZodErrorOptions,
+  type ZodError,
+} from './fromZodError';
+export { toValidationError } from './toValidationError';

--- a/lib/isValidationError.test.ts
+++ b/lib/isValidationError.test.ts
@@ -1,0 +1,22 @@
+import { isValidationError } from './isValidationError';
+import { ValidationError } from './ValidationError';
+
+describe('isValidationError()', () => {
+  test('returns true when argument is instance of ValidationError', () => {
+    expect(isValidationError(new ValidationError('foobar'))).toEqual(true);
+  });
+
+  test('returns false when argument is plain Error', () => {
+    expect(isValidationError(new Error('foobar'))).toEqual(false);
+  });
+
+  test('returns false when argument is not an Error', () => {
+    expect(isValidationError('foobar')).toEqual(false);
+    expect(isValidationError(123)).toEqual(false);
+    expect(
+      isValidationError({
+        message: 'foobar',
+      })
+    ).toEqual(false);
+  });
+});

--- a/lib/isValidationError.ts
+++ b/lib/isValidationError.ts
@@ -1,0 +1,5 @@
+import { ValidationError } from './ValidationError';
+
+export function isValidationError(err: unknown): err is ValidationError {
+  return err instanceof ValidationError;
+}

--- a/lib/isValidationErrorLike.test.ts
+++ b/lib/isValidationErrorLike.test.ts
@@ -1,0 +1,29 @@
+import { isValidationErrorLike } from './isValidationErrorLike';
+import { ValidationError } from './ValidationError';
+
+describe('isValidationErrorLike()', () => {
+  test('returns true when argument is an actual instance of ValidationError', () => {
+    expect(isValidationErrorLike(new ValidationError('foobar'))).toEqual(true);
+  });
+
+  test('returns true when argument resembles a ValidationError', () => {
+    const err = new Error('foobar');
+    err.name = 'ZodValidationError'; // force ZodValidationError
+
+    expect(isValidationErrorLike(err)).toEqual(true);
+  });
+
+  test('returns false when argument is generic Error', () => {
+    expect(isValidationErrorLike(new Error('foobar'))).toEqual(false);
+  });
+
+  test('returns false when argument is not an Error instance', () => {
+    expect(isValidationErrorLike('foobar')).toEqual(false);
+    expect(isValidationErrorLike(123)).toEqual(false);
+    expect(
+      isValidationErrorLike({
+        message: 'foobar',
+      })
+    ).toEqual(false);
+  });
+});

--- a/lib/isValidationErrorLike.test.ts
+++ b/lib/isValidationErrorLike.test.ts
@@ -7,9 +7,7 @@ describe('isValidationErrorLike()', () => {
   });
 
   test('returns true when argument resembles a ValidationError', () => {
-    const err = new Error('foobar');
-    err.name = 'ZodValidationError'; // force ZodValidationError
-
+    const err = new ValidationError('foobar');
     expect(isValidationErrorLike(err)).toEqual(true);
   });
 

--- a/lib/isValidationErrorLike.ts
+++ b/lib/isValidationErrorLike.ts
@@ -1,0 +1,5 @@
+import { ValidationError } from './ValidationError';
+
+export function isValidationErrorLike(err: unknown): err is ValidationError {
+  return err instanceof Error && err.name === 'ZodValidationError';
+}

--- a/lib/prefixMessage.ts
+++ b/lib/prefixMessage.ts
@@ -1,0 +1,23 @@
+import { PREFIX } from './config';
+
+export function prefixMessage(
+  message: string,
+  prefix: string | null,
+  prefixSeparator: string
+): string {
+  if (prefix !== null) {
+    if (message.length > 0) {
+      return [prefix, message].join(prefixSeparator);
+    }
+
+    return prefix;
+  }
+
+  if (message.length > 0) {
+    return message;
+  }
+
+  // if both reason and prefix are empty, return default prefix
+  // to avoid having an empty error message
+  return PREFIX;
+}

--- a/lib/toValidationError.ts
+++ b/lib/toValidationError.ts
@@ -1,0 +1,18 @@
+import * as zod from 'zod';
+
+import { fromZodError } from './fromZodError';
+import { ValidationError } from './ValidationError';
+
+export const toValidationError =
+  (options: Parameters<typeof fromZodError>[1] = {}) =>
+  (err: unknown): ValidationError => {
+    if (err instanceof zod.ZodError) {
+      return fromZodError(err, options);
+    }
+
+    if (err instanceof Error) {
+      return new ValidationError(err.message, { cause: err });
+    }
+
+    return new ValidationError('Unknown error');
+  };


### PR DESCRIPTION
Previously, `ValidationError` accepted `Array<ZodIssue>` as 2nd parameter. Now, it accepts `ErrorOptions` which contains a `cause` property. If `cause` is a `ZodError` then it will extract the attached issues and expose them over `error.details`.

### Why?

This change allows us to use `ValidationError` like a native JavaScript [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error). For example, we can now do:

```typescript
import { ValidationError } from 'zod-validation-error';

try {
  // attempt to do something that might throw an error
} catch (err) {
  throw new ValidationError('Something went deeply wrong', { cause: err });
}
```

This PR fixes #210