### PR TITLE
fix: esm module import in bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,13 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Hi!

Thanks for this great package!

I noticed when I import it and bundle my project with Rollup, the bundler chooses to use the CommonJS version.
That wouldn't be a huge problem on it's own, but Zod also gets reimported in it's CJS version and It increases my raw bundle size by 126kb.

![image](https://github.com/causaly/zod-validation-error/assets/3886658/d655a12d-9c11-469a-b924-274505ed32c7)

Using the `module` key in the `package.json` is a non-standard solution which is not always recognized by the bundlers.
To solve this we can add conditional exports to the `package.json` [like they have](https://github.com/colinhacks/zod/blob/a5a9d31018f9c27000461529c582c50ade2d3937/package.json#L47-L55) it in the `zod` package.

Thanks,
zsilbi
