### PR TITLE
fix: drop exports declaration from package.json

### DIFF
--- a/.changeset/wet-moons-sip.md
+++ b/.changeset/wet-moons-sip.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': patch
+---
+
+Revert package.json exports causing dependant projects to fail

--- a/package.json
+++ b/package.json
@@ -27,13 +27,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/types/index.d.ts",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
-    }
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Drop `exports` declaration from `package.json` until further notice. _Why?_ Because although the configuration appears to be correct the change causes dependant modules to fail.

The `exports` change is not trivial and requires further investigation before being adopted.

Fixes #253 

cc/ @zsilbi
