### PR TITLE
feat: nicer `z.function()` messages

### DIFF
--- a/lib/fromZodIssue.test.ts
+++ b/lib/fromZodIssue.test.ts
@@ -30,6 +30,84 @@ describe('fromZodIssue()', () => {
     }
   });
 
+  test('handles zod.function() argument errors', () => {
+    const fn = zod
+      .function()
+      .args(zod.number())
+      .implement((num) => num * 2);
+
+    try {
+      // @ts-expect-error Intentionally wrong to exercise runtime checking
+      fn('foo');
+    } catch (err) {
+      if (err instanceof zod.ZodError) {
+        const validationError = fromZodIssue(err.issues[0]);
+        expect(validationError).toBeInstanceOf(ValidationError);
+        expect(validationError.message).toMatchInlineSnapshot(
+          `"Validation error: Invalid function arguments; Expected number, received string at index 0"`
+        );
+        expect(validationError.details).toMatchInlineSnapshot(`
+          [
+            {
+              "argumentsError": [ZodError: [
+            {
+              "code": "invalid_type",
+              "expected": "number",
+              "received": "string",
+              "path": [
+                0
+              ],
+              "message": "Expected number, received string"
+            }
+          ]],
+              "code": "invalid_arguments",
+              "message": "Invalid function arguments",
+              "path": [],
+            },
+          ]
+        `);
+      }
+    }
+  });
+
+  test('handles zod.function() return value errors', () => {
+    const fn = zod
+      .function()
+      .returns(zod.number())
+      // @ts-expect-error Intentionally wrong to exercise runtime checking
+      .implement(() => 'foo');
+
+    try {
+      fn();
+    } catch (err) {
+      if (err instanceof zod.ZodError) {
+        const validationError = fromZodIssue(err.issues[0]);
+        expect(validationError).toBeInstanceOf(ValidationError);
+        expect(validationError.message).toMatchInlineSnapshot(
+          `"Validation error: Invalid function return type; Expected number, received string"`
+        );
+        expect(validationError.details).toMatchInlineSnapshot(`
+          [
+            {
+              "code": "invalid_return_type",
+              "message": "Invalid function return type",
+              "path": [],
+              "returnTypeError": [ZodError: [
+            {
+              "code": "invalid_type",
+              "expected": "number",
+              "received": "string",
+              "path": [],
+              "message": "Expected number, received string"
+            }
+          ]],
+            },
+          ]
+        `);
+      }
+    }
+  });
+
   test('respects `includePath` prop when set to `false`', () => {
     const schema = zod.object({
       name: zod.string().min(3, '"Name" must be at least 3 characters'),

--- a/lib/fromZodIssue.ts
+++ b/lib/fromZodIssue.ts
@@ -44,6 +44,34 @@ export function getMessageFromZodIssue(props: {
       .join(unionSeparator);
   }
 
+  if (issue.code === 'invalid_arguments') {
+    return [
+      issue.message,
+      ...issue.argumentsError.issues.map((issue) =>
+        getMessageFromZodIssue({
+          issue,
+          issueSeparator,
+          unionSeparator,
+          includePath,
+        })
+      ),
+    ].join(issueSeparator);
+  }
+
+  if (issue.code === 'invalid_return_type') {
+    return [
+      issue.message,
+      ...issue.returnTypeError.issues.map((issue) =>
+        getMessageFromZodIssue({
+          issue,
+          issueSeparator,
+          unionSeparator,
+          includePath,
+        })
+      ),
+    ].join(issueSeparator);
+  }
+
   if (includePath && isNonEmptyArray(issue.path)) {
     // handle array indices
     if (issue.path.length === 1) {


### PR DESCRIPTION
# Before

```
Validation error: Invalid function arguments
```

```
Validation error: Invalid function return type
```

# After

```
Validation error: Invalid function arguments; Expected number, received string at index 0
```

```
Validation error: Invalid function return type; Expected number, received string"
```