### PR TITLE
feat: introduce fromError API

### DIFF
--- a/.changeset/dull-tools-fix.md
+++ b/.changeset/dull-tools-fix.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': minor
+---
+
+Introduce `fromError` API which is a less strict version of `fromZodError`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install zod-validation-error
 
 ```typescript
 import { z as zod } from 'zod';
-import { fromZodError } from 'zod-validation-error';
+import { fromError } from 'zod-validation-error';
 
 // create zod schema
 const zodSchema = zod.object({
@@ -40,7 +40,7 @@ try {
     email: 'foobar', // note: invalid email
   });
 } catch (err) {
-  const validationError = fromZodError(err);
+  const validationError = fromError(err);
   // the error is now readable by the user
   // you may print it to console
   console.log(validationError.toString());
@@ -90,6 +90,7 @@ Validation error: Number must be greater than 0 at "id"; Invalid email at "email
 - [isValidationErrorLike(error)](#isvalidationerrorlike)
 - [fromZodIssue(zodIssue[, options])](#fromzodissue)
 - [fromZodError(zodError[, options])](#fromzoderror)
+- [fromError(error[, options])](#fromerror)
 - [toValidationError([options]) => (error) => ValidationError](#tovalidationerror)
 
 ### ValidationError
@@ -212,6 +213,23 @@ _Why is the difference between `ZodError` and `ZodIssue`?_ A `ZodError` is a col
 #### Arguments
 
 - `zodError` - _zod.ZodError_; a ZodError instance (required)
+- `options` - _Object_; formatting options (optional)
+  - `maxIssuesInMessage` - _number_; max issues to include in user-friendly message (optional, defaults to 99)
+  - `issueSeparator` - _string_; used to concatenate issues in user-friendly message (optional, defaults to ";")
+  - `unionSeparator` - _string_; used to concatenate union-issues in user-friendly message (optional, defaults to ", or")
+  - `prefix` - _string_ or _null_; prefix to use in user-friendly message (optional, defaults to "Validation error"). Pass `null` to disable prefix completely.
+  - `prefixSeparator` - _string_; used to concatenate prefix with rest of the user-friendly message (optional, defaults to ": "). Not used when `prefix` is `null`.
+  - `includePath` - _boolean_; used to provide control on whether to include the erroneous property name suffix or not (optional, defaults to `true`).
+
+### fromError
+
+Converts an error to `ValidationError`.
+
+_Why is the difference between `fromError` and `fromZodError`?_ The `fromError` is a less strict version of `fromZodError` that can accept an unknown error and attempt to convert it to a `ValidationError`.
+
+#### Arguments
+
+- `error` - _unknown_; an error (required)
 - `options` - _Object_; formatting options (optional)
   - `maxIssuesInMessage` - _number_; max issues to include in user-friendly message (optional, defaults to 99)
   - `issueSeparator` - _string_; used to concatenate issues in user-friendly message (optional, defaults to ";")

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Validation error: Number must be greater than 0 at "id"; Invalid email at "email
 - [errorMap](#errormap)
 - [isValidationError(error)](#isvalidationerror)
 - [isValidationErrorLike(error)](#isvalidationerrorlike)
+- [fromError(error[, options])](#fromerror)
 - [fromZodIssue(zodIssue[, options])](#fromzodissue)
 - [fromZodError(zodError[, options])](#fromzoderror)
-- [fromError(error[, options])](#fromerror)
 - [toValidationError([options]) => (error) => ValidationError](#tovalidationerror)
 
 ### ValidationError
@@ -190,6 +190,23 @@ const invalidErr = new Error('foobar');
 isValidationErrorLike(err); // returns false
 ```
 
+### fromError
+
+Converts an error to `ValidationError`.
+
+_Why is the difference between `fromError` and `fromZodError`?_ The `fromError` is a less strict version of `fromZodError` that can accept an unknown error and attempt to convert it to a `ValidationError`.
+
+#### Arguments
+
+- `error` - _unknown_; an error (required)
+- `options` - _Object_; formatting options (optional)
+  - `maxIssuesInMessage` - _number_; max issues to include in user-friendly message (optional, defaults to 99)
+  - `issueSeparator` - _string_; used to concatenate issues in user-friendly message (optional, defaults to ";")
+  - `unionSeparator` - _string_; used to concatenate union-issues in user-friendly message (optional, defaults to ", or")
+  - `prefix` - _string_ or _null_; prefix to use in user-friendly message (optional, defaults to "Validation error"). Pass `null` to disable prefix completely.
+  - `prefixSeparator` - _string_; used to concatenate prefix with rest of the user-friendly message (optional, defaults to ": "). Not used when `prefix` is `null`.
+  - `includePath` - _boolean_; used to provide control on whether to include the erroneous property name suffix or not (optional, defaults to `true`).
+
 ### fromZodIssue
 
 Converts a single zod issue to `ValidationError`.
@@ -213,23 +230,6 @@ _Why is the difference between `ZodError` and `ZodIssue`?_ A `ZodError` is a col
 #### Arguments
 
 - `zodError` - _zod.ZodError_; a ZodError instance (required)
-- `options` - _Object_; formatting options (optional)
-  - `maxIssuesInMessage` - _number_; max issues to include in user-friendly message (optional, defaults to 99)
-  - `issueSeparator` - _string_; used to concatenate issues in user-friendly message (optional, defaults to ";")
-  - `unionSeparator` - _string_; used to concatenate union-issues in user-friendly message (optional, defaults to ", or")
-  - `prefix` - _string_ or _null_; prefix to use in user-friendly message (optional, defaults to "Validation error"). Pass `null` to disable prefix completely.
-  - `prefixSeparator` - _string_; used to concatenate prefix with rest of the user-friendly message (optional, defaults to ": "). Not used when `prefix` is `null`.
-  - `includePath` - _boolean_; used to provide control on whether to include the erroneous property name suffix or not (optional, defaults to `true`).
-
-### fromError
-
-Converts an error to `ValidationError`.
-
-_Why is the difference between `fromError` and `fromZodError`?_ The `fromError` is a less strict version of `fromZodError` that can accept an unknown error and attempt to convert it to a `ValidationError`.
-
-#### Arguments
-
-- `error` - _unknown_; an error (required)
 - `options` - _Object_; formatting options (optional)
   - `maxIssuesInMessage` - _number_; max issues to include in user-friendly message (optional, defaults to 99)
   - `issueSeparator` - _string_; used to concatenate issues in user-friendly message (optional, defaults to ";")

--- a/lib/fromError.test.ts
+++ b/lib/fromError.test.ts
@@ -1,0 +1,50 @@
+import * as zod from 'zod';
+
+import { fromError } from './fromError.ts';
+
+describe('fromError()', () => {
+  test('handles a ZodError', () => {
+    const schema = zod.string().email();
+    const { error } = schema.safeParse('foobar');
+
+    const validationError = fromError(error);
+
+    expect(validationError).toMatchInlineSnapshot(
+      `[ZodValidationError: Validation error: Invalid email]`
+    );
+  });
+
+  test('handles a generic Error', () => {
+    const error = new Error('Something went wrong');
+
+    const validationError = fromError(error);
+
+    expect(validationError).toMatchInlineSnapshot(
+      `[ZodValidationError: Something went wrong]`
+    );
+  });
+
+  test('handles a random input', () => {
+    const error = 'I am pretending to be an error';
+
+    const validationError = fromError(error);
+
+    expect(validationError).toMatchInlineSnapshot(
+      `[ZodValidationError: Unknown error]`
+    );
+  });
+
+  test('respects options provided', () => {
+    const schema = zod.object({
+      username: zod.string().min(1),
+      password: zod.string().min(1),
+    });
+    const { error } = schema.safeParse({});
+
+    const validationError = fromError(error, { issueSeparator: ', ' });
+
+    expect(validationError).toMatchInlineSnapshot(
+      `[ZodValidationError: Validation error: Required at "username", Required at "password"]`
+    );
+  });
+});

--- a/lib/fromError.ts
+++ b/lib/fromError.ts
@@ -1,0 +1,13 @@
+import { toValidationError } from './toValidationError.ts';
+import type { FromZodErrorOptions } from './fromZodError.ts';
+import type { ValidationError } from './ValidationError.ts';
+
+/**
+ * This function is a non-curried version of `toValidationError`
+ */
+export function fromError(
+  err: unknown,
+  options: FromZodErrorOptions = {}
+): ValidationError {
+  return toValidationError(options)(err);
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ export { ValidationError, type ErrorOptions } from './ValidationError.ts';
 export { isValidationError } from './isValidationError.ts';
 export { isValidationErrorLike } from './isValidationErrorLike.ts';
 export { errorMap } from './errorMap.ts';
+export { fromError } from './fromError.ts';
 export {
   fromZodIssue,
   type FromZodIssueOptions,


### PR DESCRIPTION
This PR introduces `fromError` API, which is basically the non-curried version of the existing `toValidationError`. 