### PR TITLE
chore: add runtime check in fromZodError and throw TypeError on bad usage

### DIFF
--- a/.changeset/itchy-elephants-judge.md
+++ b/.changeset/itchy-elephants-judge.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': minor
+---
+
+Add runtime check in `fromZodError` and throw dev-friendly `TypeError` suggesting usage of `fromError` instead

--- a/lib/fromZodError.test.ts
+++ b/lib/fromZodError.test.ts
@@ -465,7 +465,7 @@ describe('fromZodError()', () => {
       expect(err).toBeInstanceOf(TypeError);
       // @ts-expect-error
       expect(err.message).toMatchInlineSnapshot(
-        `"In order to use "fromZodError" the input should be of "ZodError" instance. Otherwise consider using the less strict "fromError""`
+        `"Invalid zodError param; expected instance of ZodError. Did you mean to use the "fromError" method instead?"`
       );
     }
   });

--- a/lib/fromZodError.test.ts
+++ b/lib/fromZodError.test.ts
@@ -454,4 +454,19 @@ describe('fromZodError()', () => {
       }
     }
   });
+
+  test('throws a dev-friendly TypeError on invalid input', () => {
+    const input = new Error("I wish I was a ZodError, but I'm not");
+
+    try {
+      // @ts-expect-error
+      fromZodError(input);
+    } catch (err) {
+      expect(err).toBeInstanceOf(TypeError);
+      // @ts-expect-error
+      expect(err.message).toMatchInlineSnapshot(
+        `"In order to use "fromZodError" the input should be of "ZodError" instance. Otherwise consider using the less strict "fromError""`
+      );
+    }
+  });
 });

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -24,7 +24,7 @@ export function fromZodError(
 ): ValidationError {
   if (!(zodError instanceof zod.ZodError)) {
     throw new TypeError(
-      `In order to use "${fromZodError.name}" the input should be of "ZodError" instance. Otherwise consider using the less strict "${fromError.name}"`
+      `Invalid zodError param; expected instance of ZodError. Did you mean to use the "${fromError.name}" method instead?`
     );
   }
 

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -1,3 +1,4 @@
+import * as zod from 'zod';
 import {
   ISSUE_SEPARATOR,
   MAX_ISSUES_IN_MESSAGE,
@@ -8,8 +9,8 @@ import {
 import { getMessageFromZodIssue } from './fromZodIssue.ts';
 import { prefixMessage } from './prefixMessage.ts';
 import { ValidationError } from './ValidationError.ts';
+import { fromError } from './fromError.ts';
 import type { FromZodIssueOptions } from './fromZodIssue.ts';
-import type * as zod from 'zod';
 
 export type ZodError = zod.ZodError;
 
@@ -21,6 +22,12 @@ export function fromZodError(
   zodError: ZodError,
   options: FromZodErrorOptions = {}
 ): ValidationError {
+  if (!(zodError instanceof zod.ZodError)) {
+    throw new TypeError(
+      `In order to use "${fromZodError.name}" the input should be of "ZodError" instance. Otherwise consider using the less strict "${fromError.name}"`
+    );
+  }
+
   const {
     maxIssuesInMessage = MAX_ISSUES_IN_MESSAGE,
     issueSeparator = ISSUE_SEPARATOR,


### PR DESCRIPTION
This PR was an idea which came up as an outcome from this issue https://github.com/causaly/zod-validation-error/issues/42, and simply adds a runtime check in `fromZodError` which instructs consumers to use the less strict version of it, `fromError` .