### PR TITLE
Match ZodError via heuristics instead of instanceof

### DIFF
--- a/lib/ValidationError.ts
+++ b/lib/ValidationError.ts
@@ -1,4 +1,5 @@
-import * as zod from 'zod';
+import { isZodErrorLike } from './isZodErrorLike.ts';
+import type * as zod from 'zod';
 
 // make zod-validation-error compatible with
 // earlier to es2022 typescript configurations
@@ -28,7 +29,7 @@ function getIssuesFromErrorOptions(
   if (options) {
     const cause = options.cause;
 
-    if (cause instanceof zod.ZodError) {
+    if (isZodErrorLike(cause)) {
       return cause.issues;
     }
   }

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -1,4 +1,3 @@
-import * as zod from 'zod';
 import {
   ISSUE_SEPARATOR,
   MAX_ISSUES_IN_MESSAGE,
@@ -10,6 +9,8 @@ import { getMessageFromZodIssue } from './fromZodIssue.ts';
 import { prefixMessage } from './prefixMessage.ts';
 import { ValidationError } from './ValidationError.ts';
 import { fromError } from './fromError.ts';
+import { isZodErrorLike } from './isZodErrorLike.ts';
+import type * as zod from 'zod';
 import type { FromZodIssueOptions } from './fromZodIssue.ts';
 
 export type ZodError = zod.ZodError;
@@ -22,12 +23,22 @@ export function fromZodError(
   zodError: ZodError,
   options: FromZodErrorOptions = {}
 ): ValidationError {
-  if (!(zodError instanceof zod.ZodError)) {
+  // perform runtime check to ensure the input is a ZodError
+  // why? because people have been historically using this function incorrectly
+  // and then complain on github that it doesn't work
+  if (!isZodErrorLike(zodError)) {
     throw new TypeError(
       `Invalid zodError param; expected instance of ZodError. Did you mean to use the "${fromError.name}" method instead?`
     );
   }
 
+  return fromZodErrorWithoutRuntimeCheck(zodError, options);
+}
+
+export function fromZodErrorWithoutRuntimeCheck(
+  zodError: ZodError,
+  options: FromZodErrorOptions = {}
+): ValidationError {
   const {
     maxIssuesInMessage = MAX_ISSUES_IN_MESSAGE,
     issueSeparator = ISSUE_SEPARATOR,

--- a/lib/fromZodError.ts
+++ b/lib/fromZodError.ts
@@ -25,7 +25,6 @@ export function fromZodError(
 ): ValidationError {
   // perform runtime check to ensure the input is a ZodError
   // why? because people have been historically using this function incorrectly
-  // and then complain on github that it doesn't work
   if (!isZodErrorLike(zodError)) {
     throw new TypeError(
       `Invalid zodError param; expected instance of ZodError. Did you mean to use the "${fromError.name}" method instead?`

--- a/lib/fromZodIssue.test.ts
+++ b/lib/fromZodIssue.test.ts
@@ -2,6 +2,7 @@ import * as zod from 'zod';
 
 import { fromZodIssue } from './fromZodIssue.ts';
 import { ValidationError } from './ValidationError.ts';
+import { isZodErrorLike } from './isZodErrorLike.ts';
 
 describe('fromZodIssue()', () => {
   test('handles zod.string() schema errors', () => {
@@ -10,7 +11,7 @@ describe('fromZodIssue()', () => {
     try {
       schema.parse('foobar');
     } catch (err) {
-      if (err instanceof zod.ZodError) {
+      if (isZodErrorLike(err)) {
         const validationError = fromZodIssue(err.issues[0]);
         expect(validationError).toBeInstanceOf(ValidationError);
         expect(validationError.message).toMatchInlineSnapshot(
@@ -40,7 +41,7 @@ describe('fromZodIssue()', () => {
       // @ts-expect-error Intentionally wrong to exercise runtime checking
       fn('foo');
     } catch (err) {
-      if (err instanceof zod.ZodError) {
+      if (isZodErrorLike(err)) {
         const validationError = fromZodIssue(err.issues[0]);
         expect(validationError).toBeInstanceOf(ValidationError);
         expect(validationError.message).toMatchInlineSnapshot(
@@ -80,7 +81,7 @@ describe('fromZodIssue()', () => {
     try {
       fn();
     } catch (err) {
-      if (err instanceof zod.ZodError) {
+      if (isZodErrorLike(err)) {
         const validationError = fromZodIssue(err.issues[0]);
         expect(validationError).toBeInstanceOf(ValidationError);
         expect(validationError.message).toMatchInlineSnapshot(
@@ -116,7 +117,7 @@ describe('fromZodIssue()', () => {
     try {
       schema.parse({ name: 'jo' });
     } catch (err) {
-      if (err instanceof zod.ZodError) {
+      if (isZodErrorLike(err)) {
         const validationError = fromZodIssue(err.issues[0], {
           includePath: false,
         });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 export { ValidationError, type ErrorOptions } from './ValidationError.ts';
 export { isValidationError } from './isValidationError.ts';
 export { isValidationErrorLike } from './isValidationErrorLike.ts';
+export { isZodErrorLike } from './isZodErrorLike.ts';
 export { errorMap } from './errorMap.ts';
 export { fromError } from './fromError.ts';
 export {

--- a/lib/isZodErrorLike.test.ts
+++ b/lib/isZodErrorLike.test.ts
@@ -31,18 +31,51 @@ describe('isZodErrorLike()', () => {
     expect(isZodErrorLike(err)).toEqual(true);
   });
 
-  test('returns false when argument is generic Error', () => {
-    expect(isZodErrorLike(new Error('foobar'))).toEqual(false);
+  test('returns false when argument resembles a ZodError but does not have issues', () => {
+    const err = new CustomZodError('foobar');
+    // @ts-expect-error
+    err.issues = undefined;
+
+    expect(isZodErrorLike(err)).toEqual(false);
   });
 
-  test('returns false when argument is not an Error instance', () => {
-    expect(isZodErrorLike('foobar')).toEqual(false);
-    expect(isZodErrorLike(123)).toEqual(false);
-    expect(
-      isZodErrorLike({
-        name: 'ZodError',
-        issues: [],
-      })
-    ).toEqual(false);
+  test('returns false when argument resembles a ZodError but has the wrong name', () => {
+    const err = new CustomZodError('foobar');
+    err.name = 'foobar';
+
+    expect(isZodErrorLike(err)).toEqual(false);
+  });
+
+  test('returns false when argument is generic Error', () => {
+    const err = new Error('foobar');
+
+    expect(isZodErrorLike(err)).toEqual(false);
+  });
+
+  test('returns false when argument is string', () => {
+    const err = 'error message';
+
+    expect(isZodErrorLike(err)).toEqual(false);
+  });
+
+  test('returns false when argument is number', () => {
+    const err = 123;
+
+    expect(isZodErrorLike(err)).toEqual(false);
+  });
+
+  test('returns false when argument is object', () => {
+    const err = {};
+
+    expect(isZodErrorLike(err)).toEqual(false);
+  });
+
+  test('returns false when argument is object, even if it carries the same props as an actual ZodError', () => {
+    const err = {
+      name: 'ZodError',
+      issues: [],
+    };
+
+    expect(isZodErrorLike(err)).toEqual(false);
   });
 });

--- a/lib/isZodErrorLike.test.ts
+++ b/lib/isZodErrorLike.test.ts
@@ -1,0 +1,48 @@
+import * as zod from 'zod';
+import { isZodErrorLike } from './isZodErrorLike.ts';
+
+class CustomZodError extends Error {
+  issues: zod.ZodIssue[];
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ZodError';
+    this.issues = [];
+  }
+}
+
+describe('isZodErrorLike()', () => {
+  test('returns true when argument is an actual instance of ZodError', () => {
+    const err = new zod.ZodError([
+      {
+        code: zod.ZodIssueCode.custom,
+        path: [],
+        message: 'foobar',
+        fatal: true,
+      },
+    ]);
+
+    expect(isZodErrorLike(err)).toEqual(true);
+  });
+
+  test('returns true when argument resembles a ZodError', () => {
+    const err = new CustomZodError('foobar');
+
+    expect(isZodErrorLike(err)).toEqual(true);
+  });
+
+  test('returns false when argument is generic Error', () => {
+    expect(isZodErrorLike(new Error('foobar'))).toEqual(false);
+  });
+
+  test('returns false when argument is not an Error instance', () => {
+    expect(isZodErrorLike('foobar')).toEqual(false);
+    expect(isZodErrorLike(123)).toEqual(false);
+    expect(
+      isZodErrorLike({
+        name: 'ZodError',
+        issues: [],
+      })
+    ).toEqual(false);
+  });
+});

--- a/lib/isZodErrorLike.ts
+++ b/lib/isZodErrorLike.ts
@@ -1,5 +1,10 @@
 import type * as zod from 'zod';
 
 export function isZodErrorLike(err: unknown): err is zod.ZodError {
-  return err instanceof Error && err.name === 'ZodError';
+  return (
+    err instanceof Error &&
+    err.name === 'ZodError' &&
+    'issues' in err &&
+    Array.isArray(err.issues)
+  );
 }

--- a/lib/isZodErrorLike.ts
+++ b/lib/isZodErrorLike.ts
@@ -1,0 +1,5 @@
+import type * as zod from 'zod';
+
+export function isZodErrorLike(err: unknown): err is zod.ZodError {
+  return err instanceof Error && err.name === 'ZodError';
+}

--- a/lib/toValidationError.ts
+++ b/lib/toValidationError.ts
@@ -1,13 +1,15 @@
-import * as zod from 'zod';
-
-import { fromZodError } from './fromZodError.ts';
 import { ValidationError } from './ValidationError.ts';
+import { isZodErrorLike } from './isZodErrorLike.ts';
+import {
+  fromZodErrorWithoutRuntimeCheck,
+  type fromZodError,
+} from './fromZodError.ts';
 
 export const toValidationError =
   (options: Parameters<typeof fromZodError>[1] = {}) =>
   (err: unknown): ValidationError => {
-    if (err instanceof zod.ZodError) {
-      return fromZodError(err, options);
+    if (isZodErrorLike(err)) {
+      return fromZodErrorWithoutRuntimeCheck(err, options);
     }
 
     if (err instanceof Error) {


### PR DESCRIPTION
Fixes #298 

It's possible that a user has multiple versions of `zod` installed in their project. In such case, the `instanceof` check (as part of [zod-validation-error/lib/toValidationError.ts](https://github.com/causaly/zod-validation-error/blob/b7c5af10fbedce76073af23a102bea359e383352/lib/toValidationError.ts#L9)) fails because it's checking for a different prototype than the one being used.

This is NOT really an issue with `zod-validation-error`. We are doing nothing wrong. However, given that multiple users affected by this issue, we can offer an alternative.

In this PR we are implementing a change that uses heuristics to match on `ZodError` instead of performing an `instanceof` check.