### PR TITLE
test(fromError): add coverage for ecmascript-native errors

### DIFF
--- a/lib/fromError.test.ts
+++ b/lib/fromError.test.ts
@@ -24,6 +24,26 @@ describe('fromError()', () => {
     );
   });
 
+  test('handles other ecmascript-native errors, such as ReferenceError', () => {
+    const error = new ReferenceError('Something went wrong');
+
+    const validationError = fromError(error);
+
+    expect(validationError).toMatchInlineSnapshot(
+      `[ZodValidationError: Something went wrong]`
+    );
+  });
+
+  test('handles other ecmascript-native errors, such as TypeError', () => {
+    const error = new TypeError('Something went wrong');
+
+    const validationError = fromError(error);
+
+    expect(validationError).toMatchInlineSnapshot(
+      `[ZodValidationError: Something went wrong]`
+    );
+  });
+
   test('handles a random input', () => {
     const error = 'I am pretending to be an error';
 


### PR DESCRIPTION
Extend `lib/fromError.test.ts` to cover ecmascript-native errors, such as `TypeError` and `ReferenceError`.

This is to address the comments in https://github.com/causaly/zod-validation-error/issues/376