### PR TITLE
handle no path property in "invalid_union" issue

### DIFF
--- a/lib/v4/errorMap/custom.ts
+++ b/lib/v4/errorMap/custom.ts
@@ -7,6 +7,6 @@ export function parseCustomIssue(
   return {
     type: issue.code,
     path: issue.path,
-    message: issue.message ?? '',
+    message: issue.message ?? 'Invalid input',
   };
 }

--- a/lib/v4/errorMap/custom.ts
+++ b/lib/v4/errorMap/custom.ts
@@ -7,7 +7,6 @@ export function parseCustomIssue(
   return {
     type: issue.code,
     path: issue.path,
-    // FIXME
     message: issue.message ?? '',
   };
 }

--- a/lib/v4/errorMap/custom.ts
+++ b/lib/v4/errorMap/custom.ts
@@ -2,11 +2,12 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree } from './types.ts';
 
 export function parseCustomIssue(
-  issue: zod.$ZodIssueCustom
+  issue: zod.$ZodRawIssue<zod.$ZodIssueCustom>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,
     path: issue.path,
-    message: issue.message,
+    // FIXME
+    message: issue.message ?? '',
   };
 }

--- a/lib/v4/errorMap/errorMap.test.ts
+++ b/lib/v4/errorMap/errorMap.test.ts
@@ -966,7 +966,7 @@ describe('errorMap', () => {
               },
             ],
           ],
-          "message": "Invalid input",
+          "message": "",
           "path": [
             "input",
           ],
@@ -1026,7 +1026,7 @@ describe('errorMap', () => {
               },
             ],
           ],
-          "message": "Invalid input",
+          "message": "",
           "path": [
             "foo",
             "bar",
@@ -1063,7 +1063,7 @@ describe('errorMap', () => {
               },
             ],
           ],
-          "message": "Invalid input",
+          "message": "",
           "path": [],
         }
       `);

--- a/lib/v4/errorMap/errorMap.test.ts
+++ b/lib/v4/errorMap/errorMap.test.ts
@@ -966,7 +966,7 @@ describe('errorMap', () => {
               },
             ],
           ],
-          "message": "",
+          "message": "Invalid input",
           "path": [
             "input",
           ],
@@ -1026,7 +1026,7 @@ describe('errorMap', () => {
               },
             ],
           ],
-          "message": "",
+          "message": "Invalid input",
           "path": [
             "foo",
             "bar",
@@ -1063,7 +1063,7 @@ describe('errorMap', () => {
               },
             ],
           ],
-          "message": "",
+          "message": "Invalid input",
           "path": [],
         }
       `);

--- a/lib/v4/errorMap/errorMap.ts
+++ b/lib/v4/errorMap/errorMap.ts
@@ -68,9 +68,9 @@ export function createErrorMap(
     }
 
     const parseFunc = issueParsers[issue.code] as (
-    iss: typeof issue,
-    opts: ErrorMapOptions
-  ) => AbstractSyntaxTree;;
+      iss: typeof issue,
+      opts: ErrorMapOptions
+    ) => AbstractSyntaxTree;
     const ast = parseFunc(issue, options);
     return ast.message;
   };

--- a/lib/v4/errorMap/errorMap.ts
+++ b/lib/v4/errorMap/errorMap.ts
@@ -16,7 +16,6 @@ import type {
 } from './types.ts';
 import type * as zod from 'zod/v4/core';
 
-
 type IssueParsers = {
   [IssueCode in IssueType]: (
     issue: zod.$ZodRawIssue<Extract<zod.$ZodIssue, { code: IssueCode }>>,

--- a/lib/v4/errorMap/errorMap.ts
+++ b/lib/v4/errorMap/errorMap.ts
@@ -16,11 +16,15 @@ import type {
 } from './types.ts';
 import type * as zod from 'zod/v4/core';
 
-const issueParsers: Record<
-  IssueType,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (issue: any, options: ErrorMapOptions) => AbstractSyntaxTree
-> = {
+
+type IssueParsers = {
+  [IssueCode in IssueType]: (
+    issue: zod.$ZodRawIssue<Extract<zod.$ZodIssue, { code: IssueCode }>>,
+    options: ErrorMapOptions
+  ) => AbstractSyntaxTree;
+};
+
+const issueParsers: IssueParsers = {
   invalid_type: parseInvalidTypeIssue,
   too_big: parseTooBigIssue,
   too_small: parseTooSmallIssue,
@@ -30,8 +34,8 @@ const issueParsers: Record<
   not_multiple_of: parseNotMultipleOfIssue,
   unrecognized_keys: parseUnrecognizedKeysIssue,
   invalid_key: parseInvalidKeyIssue,
-  custom: parseInvalidUnionIssue,
-  invalid_union: parseCustomIssue,
+  custom: parseCustomIssue,
+  invalid_union: parseInvalidUnionIssue,
 };
 
 export const defaultErrorMapOptions = {
@@ -63,7 +67,10 @@ export function createErrorMap(
       return 'Not supported issue type';
     }
 
-    const parseFunc = issueParsers[issue.code];
+    const parseFunc = issueParsers[issue.code] as (
+    iss: typeof issue,
+    opts: ErrorMapOptions
+  ) => AbstractSyntaxTree;;
     const ast = parseFunc(issue, options);
     return ast.message;
   };

--- a/lib/v4/errorMap/invalidElement.ts
+++ b/lib/v4/errorMap/invalidElement.ts
@@ -2,7 +2,7 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree } from './types.ts';
 
 export function parseInvalidElementIssue(
-  issue: zod.$ZodIssueInvalidElement
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidElement>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,

--- a/lib/v4/errorMap/invalidKey.ts
+++ b/lib/v4/errorMap/invalidKey.ts
@@ -2,7 +2,7 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree } from './types.ts';
 
 export function parseInvalidKeyIssue(
-  issue: zod.$ZodIssueInvalidKey
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidKey>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,

--- a/lib/v4/errorMap/invalidStringFormat.ts
+++ b/lib/v4/errorMap/invalidStringFormat.ts
@@ -2,7 +2,7 @@ import type { AbstractSyntaxTree, ErrorMapOptions } from './types.ts';
 import type * as zod from 'zod/v4/core';
 
 export function parseInvalidStringFormatIssue(
-  issue: zod.$ZodIssueInvalidStringFormat,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidStringFormat>,
   options: Pick<ErrorMapOptions, 'displayInvalidFormatDetails'> = {
     displayInvalidFormatDetails: false,
   }
@@ -41,13 +41,13 @@ export function parseInvalidStringFormatIssue(
   }
 }
 function isZodIssueStringStartsWith(
-  issue: zod.$ZodIssueInvalidStringFormat
-): issue is zod.$ZodIssueStringStartsWith {
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidStringFormat>
+): issue is zod.$ZodRawIssue<zod.$ZodIssueStringStartsWith> {
   return issue.format === 'starts_with';
 }
 
 function parseStringStartsWith(
-  issue: zod.$ZodIssueStringStartsWith
+  issue: zod.$ZodRawIssue<zod.$ZodIssueStringStartsWith>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,
@@ -57,12 +57,12 @@ function parseStringStartsWith(
 }
 
 function isZodIssueStringEndsWith(
-  issue: zod.$ZodIssueInvalidStringFormat
-): issue is zod.$ZodIssueStringEndsWith {
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidStringFormat>
+): issue is zod.$ZodRawIssue<zod.$ZodIssueStringEndsWith> {
   return issue.format === 'ends_with';
 }
 function parseStringEndsWith(
-  issue: zod.$ZodIssueStringEndsWith
+  issue: zod.$ZodRawIssue<zod.$ZodIssueStringEndsWith>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,
@@ -72,12 +72,12 @@ function parseStringEndsWith(
 }
 
 function isZodIssueStringIncludes(
-  issue: zod.$ZodIssueInvalidStringFormat
-): issue is zod.$ZodIssueStringIncludes {
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidStringFormat>
+): issue is zod.$ZodRawIssue<zod.$ZodIssueStringIncludes> {
   return issue.format === 'includes';
 }
 function parseStringIncludes(
-  issue: zod.$ZodIssueStringIncludes
+  issue: zod.$ZodRawIssue<zod.$ZodIssueStringIncludes>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,
@@ -87,12 +87,12 @@ function parseStringIncludes(
 }
 
 function isZodIssueStringInvalidRegex(
-  issue: zod.$ZodIssueInvalidStringFormat
-): issue is zod.$ZodIssueStringInvalidRegex {
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidStringFormat>
+): issue is zod.$ZodRawIssue<zod.$ZodIssueStringInvalidRegex> {
   return issue.format === 'regex';
 }
 function parseStringInvalidRegex(
-  issue: zod.$ZodIssueStringInvalidRegex,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueStringInvalidRegex>,
   options: Pick<ErrorMapOptions, 'displayInvalidFormatDetails'> = {
     displayInvalidFormatDetails: false,
   }
@@ -110,12 +110,12 @@ function parseStringInvalidRegex(
 }
 
 function isZodIssueStringInvalidJWT(
-  issue: zod.$ZodIssueInvalidStringFormat
-): issue is zod.$ZodIssueStringInvalidJWT {
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidStringFormat>
+): issue is zod.$ZodRawIssue<zod.$ZodIssueStringInvalidJWT> {
   return issue.format === 'jwt';
 }
 function parseStringInvalidJWT(
-  issue: zod.$ZodIssueStringInvalidJWT,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueStringInvalidJWT>,
   options: Pick<ErrorMapOptions, 'displayInvalidFormatDetails'> = {
     displayInvalidFormatDetails: false,
   }

--- a/lib/v4/errorMap/invalidType.ts
+++ b/lib/v4/errorMap/invalidType.ts
@@ -2,7 +2,7 @@ import type { AbstractSyntaxTree } from './types.ts';
 import type * as zod from 'zod/v4/core';
 
 export function parseInvalidTypeIssue(
-  issue: zod.$ZodIssueInvalidType
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidType>
 ): AbstractSyntaxTree {
   let message = `expected ${issue.expected}`;
 

--- a/lib/v4/errorMap/invalidUnion.ts
+++ b/lib/v4/errorMap/invalidUnion.ts
@@ -7,6 +7,6 @@ export function parseInvalidUnionIssue(
   return {
     type: issue.code,
     path: issue.path,
-    message: issue.message ?? '',
+    message: issue.message ?? 'Invalid input',
   };
 }

--- a/lib/v4/errorMap/invalidUnion.ts
+++ b/lib/v4/errorMap/invalidUnion.ts
@@ -7,7 +7,6 @@ export function parseInvalidUnionIssue(
   return {
     type: issue.code,
     path: issue.path,
-    // FIXME
     message: issue.message ?? '',
   };
 }

--- a/lib/v4/errorMap/invalidUnion.ts
+++ b/lib/v4/errorMap/invalidUnion.ts
@@ -2,11 +2,12 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree } from './types.ts';
 
 export function parseInvalidUnionIssue(
-  issue: zod.$ZodIssueInvalidUnion
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidUnion>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,
     path: issue.path,
-    message: issue.message,
+    // FIXME
+    message: issue.message ?? '',
   };
 }

--- a/lib/v4/errorMap/invalidValue.ts
+++ b/lib/v4/errorMap/invalidValue.ts
@@ -4,7 +4,7 @@ import type { AbstractSyntaxTree, ErrorMapOptions } from './types.ts';
 import type * as zod from 'zod/v4/core';
 
 export function parseInvalidValueIssue(
-  issue: zod.$ZodIssueInvalidValue,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueInvalidValue>,
   options: Pick<
     ErrorMapOptions,
     | 'allowedValuesSeparator'

--- a/lib/v4/errorMap/notMultipleOf.ts
+++ b/lib/v4/errorMap/notMultipleOf.ts
@@ -2,7 +2,7 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree } from './types.ts';
 
 export function parseNotMultipleOfIssue(
-  issue: zod.$ZodIssueNotMultipleOf
+  issue: zod.$ZodRawIssue<zod.$ZodIssueNotMultipleOf>
 ): AbstractSyntaxTree {
   return {
     type: issue.code,

--- a/lib/v4/errorMap/tooBig.ts
+++ b/lib/v4/errorMap/tooBig.ts
@@ -3,7 +3,7 @@ import type { AbstractSyntaxTree, ErrorMapOptions } from './types.ts';
 import type * as zod from 'zod/v4/core';
 
 export function parseTooBigIssue(
-  issue: zod.$ZodIssueTooBig,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueTooBig>,
   options: Pick<ErrorMapOptions, 'dateLocalization' | 'numberLocalization'>
 ): AbstractSyntaxTree {
   const maxValueStr =

--- a/lib/v4/errorMap/tooSmall.ts
+++ b/lib/v4/errorMap/tooSmall.ts
@@ -3,7 +3,7 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree, ErrorMapOptions } from './types.ts';
 
 export function parseTooSmallIssue(
-  issue: zod.$ZodIssueTooSmall,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueTooSmall>,
   options: Pick<ErrorMapOptions, 'dateLocalization' | 'numberLocalization'>
 ): AbstractSyntaxTree {
   const minValueStr =

--- a/lib/v4/errorMap/unrecognizedKeys.ts
+++ b/lib/v4/errorMap/unrecognizedKeys.ts
@@ -3,7 +3,7 @@ import type * as zod from 'zod/v4/core';
 import type { AbstractSyntaxTree, ErrorMapOptions } from './types.ts';
 
 export function parseUnrecognizedKeysIssue(
-  issue: zod.$ZodIssueUnrecognizedKeys,
+  issue: zod.$ZodRawIssue<zod.$ZodIssueUnrecognizedKeys>,
   options: Pick<
     ErrorMapOptions,
     | 'unrecognizedKeysSeparator'


### PR DESCRIPTION
Hello! I discovered that sometimes zod doesn't add `path` property into issue which is passed into `customError`.

As you can see [here](https://github.com/colinhacks/zod/blob/main/packages/zod/src/v4/core/util.ts#L710) `zod` has a fallback for not provided path, but doesn't pass it into `config.customError`.



Reproduction:

```js
import { z } from "zod" // types: 4.0.5
import { createErrorMap, fromError } from 'zod-validation-error/v4'; // types: 4.0.0-beta.2

z.config({
  customError: createErrorMap()
});

const mySchema = z.union([z.literal('first'), z.union([z.literal('second'), z.literal('third')])])

try {
  mySchema.parse(['fourth'])
} catch (err) {
  // Cannot read properties of undefined (reading 'concat')
  const validationError = fromError(err);
  console.log(validationError.toString());
}
```


- [x] tests passed
- [x] lint passed

PS: idk should i add tests or no, because now there no tests for issue parsers