### PR TITLE
fix: accept custom error message in discriminated union

### DIFF
--- a/.changeset/loud-kings-shout.md
+++ b/.changeset/loud-kings-shout.md
@@ -1,0 +1,5 @@
+---
+'zod-validation-error': patch
+---
+
+Improve handling for zod.discriminatedUnion errors.

--- a/lib/v4/MessageBuilder.test.ts
+++ b/lib/v4/MessageBuilder.test.ts
@@ -292,6 +292,59 @@ describe('MessageBuilder', () => {
     });
   });
 
+  describe('zod.discriminatedUnion', () => {
+    test('handles invalid input', () => {
+      const schema = zod.discriminatedUnion('type', [
+        zod.object({ type: zod.literal('a'), foo: zod.string() }),
+        zod.object({ type: zod.literal('b'), bar: zod.string() }),
+      ]);
+
+      const messageBuilder = createMessageBuilder({
+        includePath: true,
+      });
+
+      try {
+        schema.parse({});
+      } catch (err) {
+        if (isZodErrorLike(err) && isNonEmptyArray(err.issues)) {
+          const message = messageBuilder(err.issues);
+          expect(message).toMatchInlineSnapshot(
+            `"Validation error: Invalid input at "type""`
+          );
+        }
+      }
+    });
+
+    test('accepts custom error message', () => {
+      const schema = zod.discriminatedUnion(
+        'type',
+        [
+          zod.object({ type: zod.literal('a'), foo: zod.string() }),
+          zod.object({ type: zod.literal('b'), bar: zod.string() }),
+        ],
+        {
+          // custom error message
+          error: 'custom error message',
+        }
+      );
+
+      const messageBuilder = createMessageBuilder({
+        includePath: true,
+      });
+
+      try {
+        schema.parse({});
+      } catch (err) {
+        if (isZodErrorLike(err) && isNonEmptyArray(err.issues)) {
+          const message = messageBuilder(err.issues);
+          expect(message).toMatchInlineSnapshot(
+            `"Validation error: Custom error message at "type""`
+          );
+        }
+      }
+    });
+  });
+
   describe('custom errorMap', () => {
     beforeAll(() => {
       zod.config({

--- a/lib/v4/MessageBuilder.ts
+++ b/lib/v4/MessageBuilder.ts
@@ -54,7 +54,7 @@ function mapIssue(
   issue: zod.$ZodIssue,
   options: MessageBuilderOptions
 ): string {
-  if (issue.code === 'invalid_union') {
+  if (issue.code === 'invalid_union' && isNonEmptyArray(issue.errors)) {
     const individualMessages = issue.errors.map((issues) =>
       issues
         .map((subIssue) =>


### PR DESCRIPTION
Improve handling of `zod.discriminatedUnion` which manifests as `invalid_union` with an empty array of `errors`.


```json
{
  "code": "invalid_union",
  "errors": [],
  "note": "No matching discriminator",
  "discriminator": "type",
  "path": [
    "type"
  ],
  "message": "Invalid input"
}
```

Fixes #575 