### PR TITLE
chore: allow release action to create PRs and push commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC
-  contents: read
+  contents: write  # Allow pushing commits
+  pull-requests: write  # Allow creating PRs
 
 jobs:
   release:


### PR DESCRIPTION
Release action has been broken since enabling OIDC authentication. 2 LoC change are required.